### PR TITLE
Fix Windows startup, dashboard, and MCP integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .venv/
 venv/
 .pytest_cache/
+.pytest_tmp/
 .hypothesis/
 *.db
 *.db-shm

--- a/BUILD_SUMMARY_v0.6.md
+++ b/BUILD_SUMMARY_v0.6.md
@@ -1,8 +1,12 @@
-# Flux Memory v0.6 — Build Summary
+# Flux Memory v0.6 Build Summary
 
 ## Overview
 
-v0.6 is a production-ready, deployable release. It adds a full CLI, REST API, booth architecture, admin authentication, and MCP onboarding on top of the v0.5 engine.
+v0.6 introduces the first packaged Flux Memory release with a CLI, REST API,
+dashboard, booth-style service wrapper, admin authentication, and stdio MCP
+server support. Post-release Windows validation found several install and
+runtime issues that must be treated as release blockers before calling the
+package production-ready.
 
 ## What Changed
 
@@ -10,83 +14,84 @@ v0.6 is a production-ready, deployable release. It adds a full CLI, REST API, bo
 
 | File | Description |
 |------|-------------|
-| `src/flux/service.py` | `FluxService` booth architecture — ThreadPoolExecutor for reads, serial Queue for writes, async Queue for feedback, per-caller sliding-window rate limiting |
-| `src/flux/rest_api.py` | FastAPI REST API — POST /store /store/batch /retrieve /feedback, GET /health /grains, X-Caller-Id header |
-| `src/flux/admin_auth.py` | argon2 password hashing, pyotp TOTP (RFC 6238), 3-attempt lockout, session tokens |
-| `src/flux/cli.py` | click CLI — `flux init/start/stop/status/admin`, background daemon via subprocess.Popen, PID file, interactive admin menu |
+| `src/flux/service.py` | `FluxService` booth architecture with read workers, serial writes, async feedback, and per-caller rate limiting |
+| `src/flux/rest_api.py` | FastAPI REST API for store, retrieve, feedback, health, and grain listing |
+| `src/flux/admin_auth.py` | Admin password hashing, TOTP support, lockout, and session tokens |
+| `src/flux/cli.py` | Click CLI for `init`, `start`, `stop`, `status`, `admin`, `mcp`, and `mcp-config` |
+| `src/flux/__main__.py` | `python -m flux` fallback for environments where the `flux` console script is not on PATH |
 
-### Modified components
+### Corrected post-release issues
+
+| Issue | Fix |
+|-------|-----|
+| Windows `pip install --user` can install `flux.exe` outside PATH | Documented `python -m flux` fallback and recommended `pipx`; added package module entry point |
+| `flux start` claimed success before services were reachable | Start now writes logs, waits for REST/dashboard health, and reports partial failure with log path |
+| Dashboard API could hang because the dashboard used single-threaded `HTTPServer` | Dashboard now uses `ThreadingHTTPServer` |
+| Dashboard could fail under Windows console encodings due Unicode status output | Console startup message now uses ASCII |
+| REST root returned 404 | Added `GET /` service metadata endpoint |
+| REST bound to `0.0.0.0` by default | Added host config defaults and bound local services to `127.0.0.1` |
+| MCP server was stdio-only but `flux start` implied it was online/discoverable | Added explicit `flux mcp --name <instance>` command and generated client snippets |
+| MCP dependency was not declared | Added `mcp>=1.0` to default dependencies |
+| TOTP QR required optional dependency not installed by default | Added `qrcode>=7.0` to default dependencies |
+| TOTP setup did not require first-code verification | Init now verifies a 6-digit TOTP code or disables TOTP |
+| Project URLs pointed to the old repo name | Updated metadata and docs to `harsh5i/flux-memory` |
+
+### Existing core changes from v0.6
 
 | File | Change |
 |------|--------|
-| `src/flux/mcp_server.py` | Server name from `cfg.MCP_SERVER_NAME`; added `flux_onboard` and `flux_list_grains` tools; `caller_id` on all tools; booth-aware dispatch via optional `service=` |
-| `src/flux/config.py` | Added `OPERATING_MODE`, `MCP_SERVER_NAME`, port fields, booth tuning params (`READ_WORKERS`, `MAX_GRAINS_PER_CALL`, `MAX_WRITE_QUEUE_DEPTH`, `MAX_GRAINS_PER_MINUTE`), admin auth params; LLM default → `qwen2.5:7b-instruct` |
-| `src/flux/storage.py` | `check_same_thread=False` for multi-threaded access; `INSERT OR IGNORE` on `entries.feature` for concurrent-retrieve race safety |
-| `src/flux/llm.py` | Removed `MockLLMBackend` (moved to `tests/mocks.py`) |
-| `src/flux/embedding.py` | Removed `MockEmbeddingBackend` (moved to `tests/mocks.py`) |
-| `src/flux/__init__.py` | Removed mock exports from public API |
-| `pyproject.toml` | Version 0.6.0; new deps: fastapi, uvicorn, click, argon2-cffi, pyotp; `flux` CLI entry point; MIT license; project URLs |
+| `src/flux/mcp_server.py` | Server name from `cfg.MCP_SERVER_NAME`; added `flux_onboard` and `flux_list_grains`; caller IDs on tools; optional service dispatch |
+| `src/flux/config.py` | Added operating mode, service ports/hosts, booth tuning params, and admin auth params |
+| `src/flux/storage.py` | `check_same_thread=False` for multi-threaded access and `INSERT OR IGNORE` for concurrent entry creation |
+| `src/flux/llm.py` / `src/flux/embedding.py` | Moved test mocks out of production modules |
+| `pyproject.toml` | Version 0.6.0 package metadata and console script |
 
-### Bug fixes
+## Validation
 
-| Bug | Fix |
-|-----|-----|
-| §1A.9: `count_inbound_conduits` missed bidirectional shortcuts | SQL now checks `to_id=grain_id OR (from_id=grain_id AND direction='bidirectional')` |
-| §1B.1: mocks in production code | Moved `MockLLMBackend` and `MockEmbeddingBackend` to `tests/mocks.py` |
-| SQLite cross-thread crash in booth | Added `check_same_thread=False` to `FluxStore` connection |
-| Concurrent retrieval UNIQUE constraint race | `INSERT OR IGNORE` on `entries.feature` |
-| FastAPI annotation resolution with local Pydantic models | Moved models to module scope in `rest_api.py` |
+At the original v0.6 release, the suite was reported as:
 
-## Test Results
-
-```
+```text
 399 passed, 0 failed, 0 skipped
 ```
 
-### New test files (89 tests)
+Post-release validation for the Windows install/runtime fixes included:
 
-| File | Tests | Coverage |
-|------|-------|----------|
-| `tests/test_service.py` | 25 | Booth: rate limiter, lifecycle, store/batch/retrieve/feedback, concurrency |
-| `tests/test_rest_api.py` | 26 | REST: all endpoints, caller ID, rate limits, batch cap, status filters |
-| `tests/test_admin_auth.py` | 22 | Auth: setup, authenticate, lockout, sessions, password change, TOTP |
-| `tests/test_mcp_v6.py` | 16 | MCP: onboarding, list_grains, caller_id, booth dispatch, unknown tool |
+```text
+python -m compileall src\flux
+python -m flux --help
+python -m flux mcp-config --name test1
+direct REST root smoke check
+direct TOTP verify/disable smoke check
+direct MCP snippet generation smoke check
+```
 
-### Existing tests retained: 310 (zero regressions)
+The local machine used for this follow-up could not run pytest because pytest
+failed before executing project code with `PermissionError: [WinError 5]` while
+creating its temp directory. Treat the direct smoke checks as patch validation,
+not as a replacement for CI or a clean-machine pytest run.
 
-### §1B.5 compliance test
+## Remaining Release Notes
 
-`tests/test_decay.py::TestBidirectionalOrphanFix` — two tests verify:
-1. A grain reachable only via a bidirectional shortcut (`from_id=grain_id`) is NOT incorrectly marked dormant
-2. A grain with only a forward conduit still decays correctly (regression guard)
-
-## Spec compliance
-
-| Requirement | Status |
-|-------------|--------|
-| §1A.1 `flux init` CLI | ✅ |
-| §1A.2 `flux start/stop/status/admin` | ✅ |
-| §1A.4 REST API | ✅ |
-| §1A.5 `flux_onboard` MCP tool | ✅ |
-| §1A.6 `caller_id` on all MCP/REST | ✅ |
-| §1A.7 Booth architecture | ✅ |
-| §1A.7a Ingestion limits | ✅ |
-| §1A.8 Admin auth (argon2 + TOTP) | ✅ |
-| §1A.9 Bidirectional orphan fix | ✅ |
-| §1B.1 Zero mocks in production code | ✅ |
-| §1B.4 399 tests, zero skips | ✅ |
-| §1B.5 Bidirectional orphan test | ✅ |
+- `pip install flux-memory` itself is controlled by pip and will remain plain
+  text. Flux can improve the first-run CLI experience, but package install
+  output should not rely on post-install scripts.
+- Stdio MCP servers are not automatically discoverable by Codex, Claude, or
+  Cursor. Users must add the generated client config snippet, or the product
+  must ship an explicit installer/integration command for each client.
+- The dashboard and MCP flows need end-to-end CI coverage on Windows before the
+  release should be described as production-ready.
 
 ## Installation
 
 ```bash
 pip install flux-memory==0.6.0
-flux init --name my-memory
-flux start --name my-memory
+python -m flux init --name my-memory
+python -m flux start --name my-memory
+python -m flux mcp-config --name my-memory
 ```
 
 ## Repository
 
-https://github.com/harsh5i/v0.5-flux-memory
+https://github.com/harsh5i/flux-memory
 
 Tag: `v0.6`

--- a/BUILD_SUMMARY_v0.6.md
+++ b/BUILD_SUMMARY_v0.6.md
@@ -30,6 +30,7 @@ package production-ready.
 | Dashboard could fail under Windows console encodings due Unicode status output | Console startup message now uses ASCII |
 | REST root returned 404 | Added `GET /` service metadata endpoint |
 | REST bound to `0.0.0.0` by default | Added host config defaults and bound local services to `127.0.0.1` |
+| Users need a phone-friendly dashboard on the local network | Added `flux start --broadcast`, LAN URL output, responsive mobile graph controls, bottom-sheet panels, and `/mobile-preview` |
 | MCP server was stdio-only but `flux start` implied it was online/discoverable | Added explicit `flux mcp --name <instance>` command and generated client snippets |
 | MCP dependency was not declared | Added `mcp>=1.0` to default dependencies |
 | TOTP QR required optional dependency not installed by default | Added `qrcode>=7.0` to default dependencies |

--- a/BUILD_SUMMARY_v0.6.md
+++ b/BUILD_SUMMARY_v0.6.md
@@ -44,7 +44,7 @@ package production-ready.
 | `src/flux/config.py` | Added operating mode, service ports/hosts, booth tuning params, and admin auth params |
 | `src/flux/storage.py` | `check_same_thread=False` for multi-threaded access and `INSERT OR IGNORE` for concurrent entry creation |
 | `src/flux/llm.py` / `src/flux/embedding.py` | Moved test mocks out of production modules |
-| `pyproject.toml` | Version 0.6.0 package metadata and console script |
+| `pyproject.toml` | Version 0.6.1 package metadata and console script |
 
 ## Validation
 
@@ -84,7 +84,7 @@ not as a replacement for CI or a clean-machine pytest run.
 ## Installation
 
 ```bash
-pip install flux-memory==0.6.0
+pip install flux-memory==0.6.1
 python -m flux init --name my-memory
 python -m flux start --name my-memory
 python -m flux mcp-config --name my-memory

--- a/BUILD_SUMMARY_v0.6.md
+++ b/BUILD_SUMMARY_v0.6.md
@@ -78,6 +78,10 @@ not as a replacement for CI or a clean-machine pytest run.
 - Stdio MCP servers are not automatically discoverable by Codex, Claude, or
   Cursor. Users must add the generated client config snippet, or the product
   must ship an explicit installer/integration command for each client.
+- Flux onboarding instructions should be persisted into an always-loaded agent
+  instruction surface, such as `AGENTS.md`, not only into memory. Otherwise the
+  agent must remember to use Flux before it can retrieve the instruction that
+  tells it to use Flux.
 - The dashboard and MCP flows need end-to-end CI coverage on Windows before the
   release should be described as production-ready.
 

--- a/DASHBOARD_DESIGN_BRIEF.md
+++ b/DASHBOARD_DESIGN_BRIEF.md
@@ -1,0 +1,295 @@
+# Flux Memory Dashboard Design Brief
+
+This is the context to hand to a UI/design assistant before redesigning the Flux Memory dashboard.
+
+## Goal
+
+Build a professional, modern, interactive operational dashboard for Flux Memory. The current dashboard works but is visually flat and the graph is static. The desired result should feel like a dense observability/control surface, not a marketing page.
+
+Primary improvements:
+
+- Interactive graph: pan, zoom, drag nodes, hover tooltips, click-to-inspect node/edge details, highlight connected neighborhood.
+- Useful controls: search, node-type filters, edge-weight threshold slider, health-state filter, reset view, pause/resume layout.
+- Clear operational hierarchy: top summary metrics, health/warnings, graph explorer, recent activity/events, selected object inspector.
+- Responsive desktop-first layout that still works on mobile.
+
+## Repository Context
+
+Important files:
+
+- `src/flux/dashboard.py`
+  - Owns the current dashboard.
+  - Serves one inline HTML document from `_DASHBOARD_HTML`.
+  - Uses `ThreadingHTTPServer`, not a frontend build system.
+  - Current JS fetches same-origin `/api/health` and `/api/graph`.
+- `src/flux/visualization.py`
+  - Builds graph JSON via `export_json(store)`.
+  - Also supports GraphML/DOT export.
+- `src/flux/health.py`
+  - Computes health signals and active warnings.
+- `src/flux/rest_api.py`
+  - Separate FastAPI service on port `7465`.
+  - Useful for store/retrieve/feedback/grains, but the dashboard should normally use same-origin dashboard endpoints.
+
+Current local instance:
+
+- Dashboard: `http://localhost:7462`
+- REST API: `http://localhost:7465`
+- Instance DB: `C:\Users\harsh\.flux\test1\flux.db`
+
+## Serving Model
+
+The dashboard is intentionally simple:
+
+```python
+_DASHBOARD_HTML = r"""<!DOCTYPE html>
+...
+</html>
+"""
+```
+
+`run_dashboard(store, host="127.0.0.1", port=7462, cfg=None)` serves:
+
+- `GET /` or `/index.html`: inline HTML
+- `GET /api/health`: `flux_health(store, cfg)`
+- `GET /api/graph`: `export_json(store)`
+- `GET /api/clusters`: `cluster_view(store)`
+
+Implementation constraints:
+
+- Prefer plain HTML/CSS/JS inside `src/flux/dashboard.py`.
+- There is no React/Vite/Webpack build step.
+- If adding a graph library, either:
+  - use vanilla JS/SVG/canvas, or
+  - vendor a single JS file into the repo and serve it, or
+  - use a CDN only if a no-network fallback is acceptable.
+- Keep the dashboard same-origin: fetch `/api/health`, `/api/graph`, `/api/clusters`.
+- Avoid depending on the REST service at `7465` for the dashboard's core view.
+
+## Data Contracts
+
+### `GET /api/health`
+
+Shape:
+
+```json
+{
+  "status": "healthy|warning|critical",
+  "signals": {
+    "highway_count": {"value": 0.0, "healthy": false},
+    "core_grain_count": {"value": 0.0, "healthy": true},
+    "orphan_rate": {"value": 0.0, "healthy": true},
+    "avg_conduit_weight": {"value": 0.385, "healthy": true},
+    "dormant_grain_rate": {"value": 0.0, "healthy": false},
+    "highway_growth_rate": {"value": 0.0, "healthy": false},
+    "shortcut_creation_rate": {"value": 0.0, "healthy": false},
+    "conduit_dissolution_rate": {"value": 0.0, "healthy": false},
+    "avg_weight_drop_on_failure": {"value": 0.0, "healthy": false},
+    "promotion_events": {"value": 0.0, "healthy": false},
+    "avg_hops_per_retrieval": {"value": 0.0, "healthy": true},
+    "retrieval_success_rate": {"value": 0.0, "healthy": false},
+    "fallback_trigger_rate": {"value": 1.0, "healthy": false},
+    "feedback_compliance_rate": {"value": 0.0, "healthy": false}
+  },
+  "active_warnings": [
+    {
+      "signal": "feedback_compliance_rate",
+      "severity": "WARNING",
+      "current_value": 0.0,
+      "healthy_range": ">= 0.8",
+      "first_seen": "2026-04-23T13:43:13Z",
+      "last_seen": "2026-04-23T21:45:47Z",
+      "suggestion": "Main AI is not calling flux_feedback reliably. Prompt engineering issue."
+    }
+  ],
+  "computed_at": "2026-04-24T03:15:47.162197+05:30"
+}
+```
+
+Health signal notes:
+
+- `value` is numeric.
+- Rate values are stored as fractions, e.g. `fallback_trigger_rate = 1.0` means `100%`.
+- `healthy` is already computed by the backend.
+- `status` should drive the global status badge.
+
+### `GET /api/graph`
+
+Shape:
+
+```json
+{
+  "directed": true,
+  "multigraph": false,
+  "stats": {
+    "grains": 29,
+    "active_grains": 29,
+    "dormant_grains": 0,
+    "entries": 135,
+    "conduits": 260,
+    "embeddings": 29
+  },
+  "nodes": [
+    {
+      "id": "04e6faffdeda4921a46d775bedbf4570",
+      "label": "Codex should use Flux Memory MCP server...",
+      "node_type": "grain",
+      "decay_class": "working",
+      "status": "active",
+      "provenance": "ai_stated",
+      "context_spread": 0
+    },
+    {
+      "id": "bdbd071d8455432fbb1c774deaf5d3ba",
+      "label": "user",
+      "node_type": "entry",
+      "feature": "user"
+    }
+  ],
+  "links": [
+    {
+      "source": "entry_or_grain_id",
+      "target": "grain_id",
+      "weight": 0.5,
+      "effective_weight": 0.4998,
+      "direction": "forward|bidirectional",
+      "decay_class": "working|core|ephemeral",
+      "use_count": 0,
+      "edge_type": "earned|shortcut|bootstrap"
+    }
+  ]
+}
+```
+
+Graph semantics:
+
+- `node_type="entry"` means a feature anchor or keyword.
+- `node_type="grain"` means a memory fact.
+- Entry nodes usually connect to grain nodes.
+- Grain-to-grain links can exist, especially shortcuts.
+- `effective_weight` is the best visual edge strength because it includes lazy decay.
+- `weight` is the stored DB weight.
+- `direction="bidirectional"` should be visually distinct from normal forward edges.
+- `decay_class="core"` should visually stand out from `working`.
+- `status="dormant"` should be muted.
+
+### `GET /api/clusters`
+
+Shape:
+
+```json
+{
+  "clusters": [
+    {"cluster_id": "cluster-id", "members": ["entry-id-1", "entry-id-2"]}
+  ]
+}
+```
+
+This is optional for the first redesign but can drive cluster coloring or a clusters panel.
+
+## Current Dashboard Limitations
+
+Current graph renderer:
+
+- Static SVG.
+- No force simulation.
+- No pan/zoom.
+- No node dragging.
+- No selected-node inspector.
+- No graph controls.
+- Layout is a ring/radial approximation, so dense graphs become visually noisy.
+
+Current UI:
+
+- Dark but flat.
+- Metric cards are useful but not visually refined.
+- Warnings and health table lack context and trend/history.
+- It does not clearly distinguish operational health from graph content health.
+
+## Recommended Redesign
+
+Use a two-column operations layout on desktop:
+
+- Top band:
+  - Instance name and status.
+  - Last computed time.
+  - Refresh/auto-refresh controls.
+  - Core metrics: grains, entries, conduits, embeddings, retrieval success, fallback rate, feedback compliance.
+- Main left:
+  - Interactive graph explorer.
+  - Graph toolbar: search, type filters, weight threshold, reset view, pause layout.
+- Main right:
+  - Selected node/edge inspector.
+  - Active warnings.
+  - Health signal table grouped by graph, retrieval, feedback, decay.
+- Bottom or secondary tab:
+  - Recent events/activity if backend endpoint is added later.
+  - Cluster summary if `/api/clusters` has data.
+
+Graph interaction expectations:
+
+- Hover node: show label, type, status, provenance, degree.
+- Click node: lock selection and show details in inspector.
+- Hover/click edge: show source, target, stored weight, effective weight, use count, decay class.
+- Search should zoom/select matching nodes.
+- Weight slider should hide weak edges and isolated nodes optionally.
+- Neighborhood mode should dim unrelated nodes/edges.
+- Auto-refresh should preserve zoom, selected node, and filter state.
+
+Visual direction:
+
+- Quiet professional dark UI, high contrast text.
+- Avoid a one-hue palette. Use restrained neutrals plus cyan/green/amber/rose for state.
+- Use compact typography. This is an operational tool, not a landing page.
+- Cards should be individual panels only; avoid nested cards.
+- Keep graph full-width within its panel, not a small decorative preview.
+
+## Backend Changes Recently Made
+
+The health instrumentation gap has been remediated in the current branch:
+
+- `reinforcement.py` now emits:
+  - `feedback/conduit_reinforced`
+  - `feedback/highway_formed`
+  - `feedback/shortcut_created`
+  - `feedback/conduit_penalized`
+- `promotion.py` now emits:
+  - `feedback/promotion_triggered`
+- `decay.py` now emits:
+  - `decay/cleanup_pass_completed`
+  - `decay/expiry_pass_completed`
+- `retrieval.py` now calls promotion checks after successful feedback.
+
+So the dashboard can trust these health signals to become nonzero once the system receives retrievals, feedback, decay cleanup, and promotion activity.
+
+## Testing Expectations
+
+After modifying `src/flux/dashboard.py`:
+
+1. Run Python tests:
+
+   ```powershell
+   python -m pytest tests/test_dashboard.py tests/test_visualization.py tests/test_health.py -q
+   ```
+
+2. Start local service:
+
+   ```powershell
+   flux start --name test1
+   ```
+
+3. Open:
+
+   ```text
+   http://localhost:7462
+   ```
+
+4. Verify:
+
+- No JS console errors.
+- `/api/health` and `/api/graph` fetch successfully.
+- Graph renders with nonzero links.
+- Pan/zoom/hover/click interactions work.
+- Text does not overlap in 1366x768 desktop or narrow mobile widths.
+- Auto-refresh does not reset selection/filter state unexpectedly.
+

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ flux mcp --name my-memory
 
 from your MCP client configuration.
 
+In other words, `flux start` starts only the REST API and dashboard. It does
+not start a background network MCP server that Codex, Claude, Cursor, or other
+clients can auto-detect. Each MCP client must have its own config entry.
+
 ### Stop services
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ This binds the dashboard to `0.0.0.0`, prints LAN URLs such as
 `http://192.168.x.x:7462`, and serves a device-frame preview at
 `/mobile-preview`. The REST API remains local-only by default.
 
+For private access from outside the local network, use a tailnet/VPN such as
+Tailscale instead of router port forwarding. Keep Flux running locally, sign in
+to Tailscale on this machine and the remote device, then publish only the
+dashboard to your private tailnet:
+
+```bash
+flux start --name my-memory
+tailscale serve --http=7462 http://127.0.0.1:7462
+tailscale serve status
+```
+
+Then open `http://<tailscale-device-name>:7462` from another signed-in
+Tailscale device. This keeps the dashboard private to your tailnet and does not
+expose the REST API or MCP transport to the public internet.
+
 `flux start` does not make the stdio MCP server discoverable by itself. MCP clients launch stdio servers directly. Use the generated snippet or run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Starts:
 - REST API health endpoint at `http://localhost:7465/health`
 - Dashboard at `http://localhost:7462`
 
+To view the dashboard from a phone on the same local network, start with:
+
+```bash
+flux start --name my-memory --broadcast
+```
+
+This binds the dashboard to `0.0.0.0`, prints LAN URLs such as
+`http://192.168.x.x:7462`, and serves a device-frame preview at
+`/mobile-preview`. The REST API remains local-only by default.
+
 `flux start` does not make the stdio MCP server discoverable by itself. MCP clients launch stdio servers directly. Use the generated snippet or run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Then open `http://<tailscale-device-name>:7462` from another signed-in
 Tailscale device. This keeps the dashboard private to your tailnet and does not
 expose the REST API or MCP transport to the public internet.
 
+If you do not want an overlay app, the private alternative is your own VPN
+endpoint, usually on your router/firewall. Connect to that VPN from the office
+using an OS-supported VPN profile, then open the dashboard over the home LAN
+address printed by `flux start --name my-memory --broadcast`. Do not forward
+port `7462` directly from the router to the internet.
+
 `flux start` does not make the stdio MCP server discoverable by itself. MCP clients launch stdio servers directly. Use the generated snippet or run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ flux_onboard() -> returns workflow instructions + operating mode
 2. `flux_store(content, provenance)` - save new facts after responding
 3. `flux_feedback(trace_id, grain_id, useful)` - rate each retrieved grain
 
+For clients such as Codex, save the `flux_onboard` instructions into an
+always-loaded instruction surface, such as a project or user `AGENTS.md`.
+Saving the workflow only as a memory note is not enough, because the agent must
+already remember to use Flux before it can retrieve that note.
+
 **Available MCP tools:**
 
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 **Self-organizing retrieval fabric for AI memory.**
 
-Flux Memory is a production-ready, deployable AI memory system that persists knowledge as a self-modifying weighted graph. It learns which memories matter through feedback signals — reinforcing useful grains, decaying stale ones, and automatically clustering related knowledge.
+Flux Memory is an AI memory system that persists knowledge as a self-modifying weighted graph. It learns which memories matter through feedback signals - reinforcing useful grains, decaying stale ones, and automatically clustering related knowledge.
 
 ## Features
 
-- **Graph-based memory** — grains connected by weighted conduits, propagated via signal attenuation
-- **Self-organizing** — lazy decay, Louvain clustering, automatic promotion/demotion, shortcut reinforcement
-- **Three access paths** — MCP server (for AI agents), REST API (HTTP), Python SDK
-- **Booth architecture** — concurrent read workers, serial write queue, async feedback queue
-- **Per-caller rate limiting** — 500 grains/min default, configurable per instance
-- **Admin authentication** — argon2 password hashing, TOTP 2FA (RFC 6238), session tokens
-- **Two operating modes** — `flux_extracts` (local Ollama LLM) or `caller_extracts` (AI provides features)
+- **Graph-based memory** - grains connected by weighted conduits, propagated via signal attenuation
+- **Self-organizing** - lazy decay, Louvain clustering, automatic promotion/demotion, shortcut reinforcement
+- **Three access paths** - MCP server (for AI agents), REST API (HTTP), Python SDK
+- **Booth architecture** - concurrent read workers, serial write queue, async feedback queue
+- **Per-caller rate limiting** - 500 grains/min default, configurable per instance
+- **Admin authentication** - argon2 password hashing, TOTP 2FA (RFC 6238), session tokens
+- **Two operating modes** - `flux_extracts` (local Ollama LLM) or `caller_extracts` (AI provides features)
 
 ## Quick Start
 
@@ -21,6 +21,15 @@ Flux Memory is a production-ready, deployable AI memory system that persists kno
 ```bash
 pip install flux-memory
 ```
+
+Windows fallback if `flux` is not on PATH:
+
+```bat
+python -m flux --help
+python -m flux init --name my-memory
+```
+
+For CLI-first installs, `pipx install flux-memory` is recommended because it manages command shims and PATH setup.
 
 ### Initialize an instance
 
@@ -31,7 +40,13 @@ flux init --name my-memory
 This prompts for:
 - Operating mode (`caller_extracts` or `flux_extracts`)
 - Admin password (argon2-hashed)
-- Optional TOTP two-factor authentication
+- Optional TOTP two-factor authentication, with terminal QR and first-code verification
+
+Initialization also writes MCP client snippets under:
+
+```text
+~/.flux/<name>/integrations/
+```
 
 ### Start services
 
@@ -40,9 +55,16 @@ flux start --name my-memory
 ```
 
 Starts:
-- MCP server (stdio, for AI agent integration)
-- REST API at `http://localhost:7465`
+- REST API health endpoint at `http://localhost:7465/health`
 - Dashboard at `http://localhost:7462`
+
+`flux start` does not make the stdio MCP server discoverable by itself. MCP clients launch stdio servers directly. Use the generated snippet or run:
+
+```bash
+flux mcp --name my-memory
+```
+
+from your MCP client configuration.
 
 ### Stop services
 
@@ -58,17 +80,33 @@ flux status --name my-memory
 
 ## MCP Integration
 
-Connect Flux Memory to any MCP-compatible AI agent. On first connection, call `flux_onboard` to receive integration instructions:
+Connect Flux Memory to any MCP-compatible AI agent. Flux uses stdio MCP by default, so the client must launch Flux.
+
+Generate or refresh client snippets:
+
+```bash
+flux mcp-config --name my-memory
+```
+
+Codex example:
+
+```toml
+[mcp_servers."flux-my-memory"]
+command = "python"
+args = ["-m", "flux.cli", "mcp", "--name", "my-memory"]
+```
+
+On first connection, call `flux_onboard` to receive integration instructions:
 
 ```
-flux_onboard() → returns workflow instructions + operating mode
+flux_onboard() -> returns workflow instructions + operating mode
 ```
 
 **Standard workflow per conversation turn:**
 
-1. `flux_retrieve(query)` — fetch relevant memories before responding
-2. `flux_store(content, provenance)` — save new facts after responding
-3. `flux_feedback(trace_id, grain_id, useful)` — rate each retrieved grain
+1. `flux_retrieve(query)` - fetch relevant memories before responding
+2. `flux_store(content, provenance)` - save new facts after responding
+3. `flux_feedback(trace_id, grain_id, useful)` - rate each retrieved grain
 
 **Available MCP tools:**
 
@@ -120,7 +158,11 @@ Instance config lives at `~/.flux/<name>/config.yaml`. Key parameters:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `OPERATING_MODE` | `flux_extracts` | LLM extraction mode |
+| `MCP_HOST` | `127.0.0.1` | Reserved for network MCP transports |
+| `MCP_PORT` | `7464` | Reserved MCP port |
+| `REST_HOST` | `127.0.0.1` | REST bind host |
 | `REST_PORT` | `7465` | REST API port |
+| `DASHBOARD_HOST` | `127.0.0.1` | Dashboard bind host |
 | `DASHBOARD_PORT` | `7462` | Dashboard port |
 | `READ_WORKERS` | `3` | Concurrent read workers |
 | `MAX_GRAINS_PER_CALL` | `100` | Batch ingestion cap |
@@ -145,12 +187,12 @@ Password + TOTP gated interactive menu: search/purge/restore grains, view audit 
 ## Development
 
 ```bash
-git clone https://github.com/harsh5i/v0.5-flux-memory
-cd v0.5-flux-memory
+git clone https://github.com/harsh5i/flux-memory
+cd flux-memory
 pip install -e ".[test]"
 pytest tests/
 ```
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT - see [LICENSE](LICENSE)

--- a/config/flux.yaml
+++ b/config/flux.yaml
@@ -83,6 +83,17 @@ EXPLORATION_BOOST: 1.5
 # --- Admin channel ---
 PURGE_UNDO_WINDOW_HOURS: 24.0
 
+# --- Local services ---
+MCP_SERVER_NAME: flux-memory
+MCP_HOST: 127.0.0.1
+MCP_PORT: 7464
+REST_HOST: 127.0.0.1
+REST_PORT: 7465
+ADMIN_REST_HOST: 127.0.0.1
+ADMIN_REST_PORT: 7463
+DASHBOARD_HOST: 127.0.0.1
+DASHBOARD_PORT: 7462
+
 # --- LLM backend (not in spec §5; implementation-specific) ---
 # LLM_BASE_URL: http://localhost:11434   # Ollama API base URL
 # LLM_MODEL: llama3.1:8b

--- a/design/mobile-preview/DESIGN_HANDOFF_PROMPT.md
+++ b/design/mobile-preview/DESIGN_HANDOFF_PROMPT.md
@@ -1,0 +1,121 @@
+# Flux Mobile Dashboard Handoff Prompt
+
+Use this prompt when asking another AI, designer, or frontend engineer to recreate the same mobile dashboard layout.
+
+## Objective
+
+Recreate the Flux Memory mobile dashboard experience exactly in spirit: a professional, modern, dense, operational graph dashboard optimized for phone viewing. This is not a marketing page and not a generic card dashboard. The graph is the primary surface.
+
+Use these files as source references:
+
+- `Mobile Preview.html`
+- `Mobile Preview - live.html`
+- `Flux Dashboard.html`
+
+## Required Mobile Layout
+
+The mobile dashboard must behave like this:
+
+- First screen is the graph, not metrics cards.
+- The graph fills the available mobile viewport.
+- Controls are compact and overlaid or docked.
+- Secondary panels are hidden until opened.
+- Inspector, warnings, health, and refresh are accessed from a bottom bubble bar.
+- Tapping a node highlights it and updates inspector state.
+- Tapping the inspector bubble opens a bottom sheet.
+- The bottom sheet must slide up over the graph and be dismissible.
+- Search must dim non-matching nodes and highlight matching nodes; it must not hide the rest of the graph.
+- Search must not permanently zoom the graph; if zoom is used, it must reset cleanly.
+- Node deselection must be available by tapping empty graph space or using a clear selected state.
+
+## Device Preview Frames
+
+The preview page should include these device frames:
+
+1. iPhone Air
+   - Viewport: `390 x 844`
+   - Frame width: `280px`
+   - Screen height: `580px`
+   - Iframe scale: `0.642`
+   - Dynamic island at top
+
+2. Motorola Razr+ unfolded
+   - Viewport: `360 x 780`
+   - Frame width: `258px`
+   - Screen height: `540px`
+   - Iframe scale: `0.653`
+   - Cosmetic hinge seam across center
+
+3. Motorola Razr+ folded outer screen
+   - Viewport: `390 x 162`
+   - Frame width: `200px`
+   - Cover screen height: `120px`
+   - Iframe scale: `0.462`
+   - Ultra-compact glance mode
+
+## Visual Direction
+
+Keep the visual style close to the reference:
+
+- Dark operational interface.
+- Background near `#060810` / `#080a0e`.
+- Device shell near `#18181a` / `#1c1c1e`.
+- Accent cyan near `#22d3ee`.
+- Muted slate text for labels.
+- Compact typography.
+- Minimal decorative elements.
+- No large hero sections.
+- No oversized cards.
+- No bright marketing gradients.
+- No thick edge rendering for graph strength.
+
+## Graph Behavior
+
+The graph must feel alive and useful:
+
+- Pan and zoom on touch.
+- Drag nodes with one finger.
+- Pinch zoom with two fingers.
+- Highlight selected node and its neighborhood.
+- Dim unrelated nodes instead of removing them.
+- Show real-time or recent signal propagation when trace/activity data exists.
+- Keep static edges thin; activity can pulse along paths instead of making all edges thick.
+- Text labels must be sharp and readable; avoid blurred canvas text where possible.
+
+## Data Contracts
+
+Use same-origin dashboard APIs:
+
+- `GET /api/graph`
+- `GET /api/health`
+- `GET /api/events`
+- `GET /api/trace?trace_id=<id>`
+
+Do not require the REST API port directly from the mobile frontend.
+
+## Implementation Constraints
+
+The current Flux dashboard is plain HTML/CSS/JS embedded in:
+
+- `src/flux/dashboard.py`
+
+There is no React/Vite/Webpack build step in this Flux system. If implementing in the existing repo, keep it compatible with inline HTML/CSS/JS unless the owner explicitly approves a frontend build system.
+
+For another Flux system, either:
+
+- copy the static HTML/CSS/JS structure directly, or
+- port the same layout to that system's frontend stack while preserving behavior.
+
+## Acceptance Checklist
+
+The result is acceptable only if:
+
+- iPhone viewport opens directly into a usable graph.
+- Bottom bubble bar is visible and usable.
+- Inspector opens as a bottom sheet.
+- Search highlights matches and dims non-matches.
+- Tap empty graph deselects selected node.
+- Graph labels are readable on mobile.
+- Touch pan, pinch, and node drag work.
+- Health/warnings are reachable but do not dominate the first screen.
+- The preview page shows all three device frames.

--- a/design/mobile-preview/Flux Dashboard.html
+++ b/design/mobile-preview/Flux Dashboard.html
@@ -1,0 +1,1018 @@
+<!DOCTYPE html><html lang="en"><head>
+
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flux Memory — Dashboard</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
+<style>
+  :root {
+    --bg: #080a0e;
+    --surface: #0f1117;
+    --surface2: #161921;
+    --border: #1e2330;
+    --border2: #252c3a;
+    --text: #dde3f0;
+    --text-muted: #5a6480;
+    --text-dim: #3a4255;
+    --cyan: #22d3ee;
+    --cyan-dim: rgba(34,211,238,0.12);
+    --green: #4ade80;
+    --green-dim: rgba(74,222,128,0.12);
+    --amber: #fbbf24;
+    --amber-dim: rgba(251,191,36,0.12);
+    --rose: #f43f5e;
+    --rose-dim: rgba(244,63,94,0.12);
+    --violet: #a78bfa;
+    --violet-dim: rgba(167,139,250,0.12);
+    --radius: 6px;
+    --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    --font-ui: 'Inter', system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; background: var(--bg); color: var(--text); font-family: var(--font-ui); font-size: 13px; overflow: hidden; }
+
+  /* LAYOUT */
+  #app { display: flex; flex-direction: column; height: 100vh; }
+
+  /* TOP BAR */
+  #topbar {
+    display: flex; align-items: center; gap: 12px;
+    padding: 10px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+  #topbar .brand { display: flex; align-items: center; gap: 8px; margin-right: 4px; }
+  #topbar .brand svg { flex-shrink: 0; }
+  #topbar .brand-name { font-size: 14px; font-weight: 600; letter-spacing: -0.3px; color: var(--text); }
+  #topbar .brand-sub { font-size: 11px; color: var(--text-muted); }
+  #status-badge {
+    display: flex; align-items: center; gap: 5px;
+    padding: 3px 9px; border-radius: 20px; font-size: 11px; font-weight: 600;
+    letter-spacing: 0.4px; text-transform: uppercase;
+  }
+  .badge-healthy { background: var(--green-dim); color: var(--green); border: 1px solid rgba(74,222,128,0.3); }
+  .badge-warning { background: var(--amber-dim); color: var(--amber); border: 1px solid rgba(251,191,36,0.3); }
+  .badge-critical { background: var(--rose-dim); color: var(--rose); border: 1px solid rgba(244,63,94,0.3); }
+  .pulse { width: 6px; height: 6px; border-radius: 50%; animation: pulse 2s ease-in-out infinite; }
+  .pulse-green { background: var(--green); box-shadow: 0 0 0 0 rgba(74,222,128,0.6); }
+  .pulse-amber { background: var(--amber); box-shadow: 0 0 0 0 rgba(251,191,36,0.6); }
+  .pulse-rose { background: var(--rose); box-shadow: 0 0 0 0 rgba(244,63,94,0.6); }
+  @keyframes pulse {
+    0%,100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.4); opacity: 0.6; }
+  }
+  .divider { width: 1px; height: 20px; background: var(--border2); flex-shrink: 0; }
+  #metrics-strip { display: flex; gap: 2px; flex: 1; flex-wrap: wrap; }
+  .metric-pill {
+    display: flex; flex-direction: column; align-items: flex-start;
+    padding: 4px 12px; background: var(--surface2); border: 1px solid var(--border);
+    border-radius: var(--radius); min-width: 80px; cursor: default;
+    transition: border-color 0.15s;
+  }
+  .metric-pill:hover { border-color: var(--border2); }
+  .metric-pill .m-label { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .metric-pill .m-value { font-size: 16px; font-weight: 700; font-family: var(--font-mono); color: var(--text); line-height: 1.2; margin-top: 1px; }
+  .metric-pill .m-value.c-cyan { color: var(--cyan); }
+  .metric-pill .m-value.c-green { color: var(--green); }
+  .metric-pill .m-value.c-amber { color: var(--amber); }
+  .metric-pill .m-value.c-rose { color: var(--rose); }
+  #topbar-controls { display: flex; align-items: center; gap: 6px; margin-left: auto; }
+  #computed-at { font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); white-space: nowrap; }
+  .icon-btn {
+    display: flex; align-items: center; justify-content: center;
+    width: 28px; height: 28px; border-radius: var(--radius);
+    background: var(--surface2); border: 1px solid var(--border);
+    color: var(--text-muted); cursor: pointer; transition: all 0.15s;
+  }
+  .icon-btn:hover { color: var(--text); border-color: var(--border2); }
+  .icon-btn.active { color: var(--cyan); border-color: rgba(34,211,238,0.3); background: var(--cyan-dim); }
+  #refresh-interval { font-size: 11px; color: var(--text-muted); }
+
+  /* MAIN AREA */
+  #main { display: flex; flex: 1; overflow: hidden; }
+
+  /* LEFT: GRAPH PANEL */
+  #graph-panel { flex: 1; display: flex; flex-direction: column; min-width: 0; border-right: 1px solid var(--border); }
+  #graph-toolbar {
+    display: flex; align-items: center; gap: 8px; padding: 8px 12px;
+    background: var(--surface); border-bottom: 1px solid var(--border); flex-shrink: 0; flex-wrap: wrap;
+  }
+  #search-box {
+    display: flex; align-items: center; gap: 6px;
+    background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 4px 8px; flex: 1; max-width: 220px;
+  }
+  #search-box input {
+    background: none; border: none; outline: none; color: var(--text);
+    font-size: 12px; font-family: var(--font-ui); width: 100%;
+  }
+  #search-box input::placeholder { color: var(--text-dim); }
+  .filter-group { display: flex; align-items: center; gap: 3px; }
+  .filter-btn {
+    padding: 3px 8px; border-radius: var(--radius); font-size: 11px; font-weight: 500;
+    border: 1px solid var(--border); background: var(--surface2); color: var(--text-muted);
+    cursor: pointer; transition: all 0.15s;
+  }
+  .filter-btn.active { background: var(--cyan-dim); border-color: rgba(34,211,238,0.35); color: var(--cyan); }
+  .filter-btn.active.violet { background: var(--violet-dim); border-color: rgba(167,139,250,0.35); color: var(--violet); }
+  .slider-group { display: flex; align-items: center; gap: 6px; }
+  .slider-group label { font-size: 10px; color: var(--text-muted); white-space: nowrap; text-transform: uppercase; letter-spacing: 0.4px; }
+  #weight-slider { width: 80px; accent-color: var(--cyan); cursor: pointer; }
+  #weight-val { font-size: 11px; font-family: var(--font-mono); color: var(--cyan); min-width: 28px; }
+  #graph-container { flex: 1; position: relative; overflow: hidden; }
+  #graph-svg { width: 100%; height: 100%; display: block; }
+  #graph-overlay {
+    position: absolute; bottom: 12px; left: 12px;
+    display: flex; gap: 8px; flex-wrap: wrap;
+  }
+  .legend-item { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-muted); }
+  .legend-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  #tooltip {
+    position: fixed; pointer-events: none; z-index: 999;
+    background: var(--surface); border: 1px solid var(--border2);
+    border-radius: var(--radius); padding: 8px 10px; max-width: 260px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.5); opacity: 0; transition: opacity 0.1s;
+    font-size: 11px; line-height: 1.6;
+  }
+  #tooltip .tt-title { font-size: 12px; font-weight: 600; color: var(--text); margin-bottom: 4px; }
+  #tooltip .tt-row { display: flex; justify-content: space-between; gap: 12px; }
+  #tooltip .tt-key { color: var(--text-muted); }
+  #tooltip .tt-val { font-family: var(--font-mono); color: var(--text); }
+  #graph-stats {
+    position: absolute; top: 10px; right: 10px;
+    background: rgba(15,17,23,0.8); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 5px 9px; font-size: 10px;
+    font-family: var(--font-mono); color: var(--text-muted);
+    backdrop-filter: blur(4px);
+  }
+  #no-data-msg {
+    position: absolute; inset: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 8px;
+    color: var(--text-dim); font-size: 13px; display: none;
+  }
+
+  /* RIGHT PANEL */
+  #right-panel {
+    width: 320px; flex-shrink: 0; display: flex; flex-direction: column;
+    background: var(--surface); overflow-y: auto; overflow-x: hidden;
+  }
+  .rpanel-section {
+    border-bottom: 1px solid var(--border); flex-shrink: 0;
+  }
+  .rpanel-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 14px; cursor: pointer; user-select: none;
+  }
+  .rpanel-header-left { display: flex; align-items: center; gap: 6px; }
+  .rpanel-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.6px; color: var(--text-muted); }
+  .rpanel-count {
+    font-size: 10px; background: var(--surface2); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1px 6px; font-family: var(--font-mono); color: var(--text-muted);
+  }
+  .rpanel-count.warn { background: var(--amber-dim); border-color: rgba(251,191,36,0.3); color: var(--amber); }
+  .rpanel-body { padding: 0 14px 12px; }
+  .rpanel-chevron { color: var(--text-dim); transition: transform 0.2s; }
+  .rpanel-chevron.open { transform: rotate(180deg); }
+
+  /* INSPECTOR */
+  #inspector-empty {
+    padding: 24px 14px; text-align: center; color: var(--text-dim); font-size: 11px; line-height: 1.6;
+  }
+  .inspector-node-header { display: flex; align-items: flex-start; gap: 8px; margin-bottom: 10px; }
+  .inspector-icon { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .inspector-label { font-size: 12px; font-weight: 600; color: var(--text); line-height: 1.4; word-break: break-word; }
+  .inspector-type { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
+  .inspector-rows { display: flex; flex-direction: column; gap: 4px; }
+  .inspector-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; padding: 3px 0; border-bottom: 1px solid var(--border); }
+  .inspector-row:last-child { border-bottom: none; }
+  .ir-key { font-size: 11px; color: var(--text-muted); flex-shrink: 0; }
+  .ir-val { font-size: 11px; font-family: var(--font-mono); color: var(--text); text-align: right; word-break: break-all; }
+  .tag { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; font-weight: 500; }
+  .tag-cyan { background: var(--cyan-dim); color: var(--cyan); }
+  .tag-violet { background: var(--violet-dim); color: var(--violet); }
+  .tag-green { background: var(--green-dim); color: var(--green); }
+  .tag-amber { background: var(--amber-dim); color: var(--amber); }
+  .tag-rose { background: var(--rose-dim); color: var(--rose); }
+  .tag-dim { background: var(--surface2); color: var(--text-muted); }
+
+  /* WARNINGS */
+  .warning-card {
+    background: var(--surface2); border: 1px solid rgba(251,191,36,0.2);
+    border-radius: var(--radius); padding: 8px 10px; margin-bottom: 6px;
+  }
+  .warning-card:last-child { margin-bottom: 0; }
+  .warning-signal { font-size: 11px; font-weight: 600; color: var(--amber); font-family: var(--font-mono); }
+  .warning-msg { font-size: 11px; color: var(--text-muted); margin-top: 3px; line-height: 1.5; }
+  .warning-val { font-size: 10px; color: var(--text-dim); margin-top: 4px; font-family: var(--font-mono); }
+
+  /* HEALTH TABLE */
+  .health-group { margin-bottom: 10px; }
+  .health-group-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-dim); margin-bottom: 4px; padding-bottom: 3px; border-bottom: 1px solid var(--border); }
+  .health-row { display: flex; align-items: center; gap: 6px; padding: 3px 0; }
+  .health-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .health-row-key { flex: 1; font-size: 11px; color: var(--text-muted); }
+  .health-row-val { font-size: 11px; font-family: var(--font-mono); color: var(--text); min-width: 44px; text-align: right; }
+
+  /* SCROLLBAR */
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border2); border-radius: 2px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+  /* LOADING OVERLAY */
+  #loading {
+    position: fixed; inset: 0; background: var(--bg);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 16px; z-index: 1000;
+  }
+  .loader-ring {
+    width: 40px; height: 40px; border-radius: 50%;
+    border: 2px solid var(--border2); border-top-color: var(--cyan);
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  #loading .load-text { font-size: 12px; color: var(--text-muted); font-family: var(--font-mono); }
+
+  /* RESPONSIVE */
+  @media (max-width: 768px) {
+    #main { flex-direction: column; }
+    #right-panel { width: 100%; height: 300px; border-top: 1px solid var(--border); }
+    #graph-panel { border-right: none; }
+  }
+</style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;600&amp;display=swap" rel="stylesheet">
+</head>
+<body data-cc-id="cc-1" style="cursor: crosshair; background-color: rgb(13, 15, 25);">
+
+<div id="loading" style="display: none;">
+  <div class="loader-ring"></div>
+  <div class="load-text">Initialising Flux Memory…</div>
+</div>
+
+<div id="tooltip" style="opacity: 0; left: 532px; top: 403px;">
+  <div class="tt-title" id="tt-title">entry_9… → grain_5…</div>
+  <div id="tt-body"><div class="tt-row"><span class="tt-key">weight</span><span class="tt-val">0.8735</span></div><div class="tt-row"><span class="tt-key">eff. weight</span><span class="tt-val">0.8561</span></div><div class="tt-row"><span class="tt-key">direction</span><span class="tt-val">forward</span></div><div class="tt-row"><span class="tt-key">decay</span><span class="tt-val">core</span></div><div class="tt-row"><span class="tt-key">use count</span><span class="tt-val">14</span></div><div class="tt-row"><span class="tt-key">edge type</span><span class="tt-val">earned</span></div></div>
+</div>
+
+<div id="app">
+  <!-- TOP BAR -->
+  <div id="topbar">
+    <div class="brand">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="12" r="10" stroke="#22d3ee" stroke-width="1.5" opacity="0.3"></circle>
+        <circle cx="12" cy="12" r="6" stroke="#22d3ee" stroke-width="1.5" opacity="0.6"></circle>
+        <circle cx="12" cy="12" r="2.5" fill="#22d3ee"></circle>
+        <line x1="12" y1="2" x2="12" y2="6" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+        <line x1="12" y1="18" x2="12" y2="22" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+        <line x1="2" y1="12" x2="6" y2="12" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+        <line x1="18" y1="12" x2="22" y2="12" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+      </svg>
+      <div>
+        <div class="brand-name">Flux Memory</div>
+        <div class="brand-sub" id="instance-name">test1</div>
+      </div>
+    </div>
+    <div id="status-badge" class="badge-warning">
+      <div class="pulse pulse-amber"></div>
+      <span id="status-text">WARNING</span>
+    </div>
+    <div class="divider"></div>
+    <div id="metrics-strip">
+      <div class="metric-pill"><span class="m-label">Grains</span><span class="m-value c-cyan" id="m-grains">29</span></div>
+      <div class="metric-pill"><span class="m-label">Entries</span><span class="m-value" id="m-entries">135</span></div>
+      <div class="metric-pill"><span class="m-label">Conduits</span><span class="m-value" id="m-conduits">260</span></div>
+      <div class="metric-pill"><span class="m-label">Embeddings</span><span class="m-value" id="m-embed">29</span></div>
+      <div class="metric-pill"><span class="m-label">Retrieval</span><span class="m-value c-green" id="m-retrieval">74%</span></div>
+      <div class="metric-pill"><span class="m-label">Fallback</span><span class="m-value c-rose" id="m-fallback">100%</span></div>
+      <div class="metric-pill"><span class="m-label">Feedback</span><span class="m-value c-rose" id="m-feedback">0%</span></div>
+    </div>
+    <div class="divider"></div>
+    <div id="topbar-controls">
+      <span id="computed-at">3:15:47 AM</span>
+      <button class="icon-btn" id="refresh-btn" title="Refresh now" onclick="fetchAll()" fdprocessedid="mgt0ms">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
+      </button>
+      <button class="icon-btn" id="autorefresh-btn" title="Toggle auto-refresh" onclick="toggleAutoRefresh()" fdprocessedid="hgqnwr">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
+      </button>
+      <span id="refresh-interval" style="display: none;">30s</span>
+    </div>
+  </div>
+
+  <!-- MAIN -->
+  <div id="main">
+
+    <!-- GRAPH PANEL -->
+    <div id="graph-panel">
+      <div id="graph-toolbar">
+        <div id="search-box">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#5a6480" stroke-width="2.5"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65" stroke-opacity="0.7"></line></svg>
+          <input type="text" id="search-input" placeholder="Search nodes…" oninput="onSearch(this.value)" fdprocessedid="mqac2">
+        </div>
+        <div class="filter-group">
+          <span style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.4px">Type</span>
+          <button class="filter-btn active" id="f-grain" onclick="toggleFilter('grain')" fdprocessedid="t5jftd">Grains</button>
+          <button class="filter-btn violet active" id="f-entry" onclick="toggleFilter('entry')" fdprocessedid="pba5gd">Entries</button>
+        </div>
+        <div class="filter-group">
+          <span style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.4px">Status</span>
+          <button class="filter-btn active" id="f-active" onclick="toggleFilter('active')" fdprocessedid="5weyp">Active</button>
+          <button class="filter-btn active" id="f-dormant" onclick="toggleFilter('dormant')" fdprocessedid="r0i09a">Dormant</button>
+        </div>
+        <div class="slider-group">
+          <label>Weight ≥</label>
+          <input type="range" id="weight-slider" min="0" max="1" step="0.05" value="0" oninput="onWeightChange(this.value)">
+          <span id="weight-val">0.00</span>
+        </div>
+        <div style="margin-left:auto;display:flex;gap:4px">
+          <button class="icon-btn" id="pause-btn" title="Pause/resume layout" onclick="toggleSimulation()" fdprocessedid="hon4i">
+            <svg id="pause-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+          </button>
+          <button class="icon-btn" title="Reset view" onclick="resetView()" fdprocessedid="o9zaby">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path><path d="M3 3v5h5"></path></svg>
+          </button>
+        </div>
+      </div>
+
+      <div id="graph-container">
+        <svg id="graph-svg" width="1199" height="926"><defs><marker id="arrow-forward" viewBox="0 -4 8 8" refX="14" refY="0" markerWidth="6" markerHeight="6" orient="auto"><path d="M0,-4L8,0L0,4" fill="#1e3f5a"></path></marker><marker id="arrow-bidirectional" viewBox="0 -4 8 8" refX="14" refY="0" markerWidth="6" markerHeight="6" orient="auto"><path d="M0,-4L8,0L0,4" fill="#7c3aed"></path></marker><marker id="arrow-selected" viewBox="0 -4 8 8" refX="14" refY="0" markerWidth="6" markerHeight="6" orient="auto"><path d="M0,-4L8,0L0,4" fill="#22d3ee"></path></marker></defs><g><g><line stroke="#1e3f5a" stroke-width="0.7829153836947362" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="677.3017543299637" y1="443.453260972379" x2="628.6887497852189" y2="604.6664406533821"></line><line stroke="#38bdf8" stroke-width="1.4419822894694614" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="677.3017543299637" y1="443.453260972379" x2="766.2158109548885" y2="398.689838636173"></line><line stroke="#1e3a4a" stroke-width="0.5399159405204128" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="677.3017543299637" y1="443.453260972379" x2="801.573452340537" y2="542.8885413366817"></line><line stroke="#1e3f5a" stroke-width="1.0719683931708248" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="677.3017543299637" y1="443.453260972379" x2="556.9730006608756" y2="377.8106559082528"></line><line stroke="#38bdf8" stroke-width="2.1911848581855247" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="677.3017543299637" y1="443.453260972379" x2="587.2368528306883" y2="322.6064316404506"></line><line stroke="#1e3f5a" stroke-width="0.6722733551197346" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="433.4545857512053" y1="570.1429316463693" x2="513.7783397162622" y2="673.8496694760671"></line><line stroke="#38bdf8" stroke-width="1.0269130833221838" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="433.4545857512053" y1="570.1429316463693" x2="511.47102480515827" y2="433.6010055107934"></line><line stroke="#1e3f5a" stroke-width="1.228103783635865" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="619.4030946643481" y1="330.12741825586625" x2="700.1078494485312" y2="393.3527675352126"></line><line stroke="#38bdf8" stroke-width="2.1920988348191774" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="619.4030946643481" y1="330.12741825586625" x2="727.3033260014777" y2="358.690820500209"></line><line stroke="#1e3a4a" stroke-width="1.6410099484063978" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="619.4030946643481" y1="330.12741825586625" x2="642.2729700874014" y2="277.03437754431206"></line><line stroke="#1e3f5a" stroke-width="2.122672595465776" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="619.4030946643481" y1="330.12741825586625" x2="576.9745770083031" y2="433.2410318275608"></line><line stroke="#38bdf8" stroke-width="1.348714589003547" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="619.4030946643481" y1="330.12741825586625" x2="515.8799720809257" y2="242.40663621075785"></line><line stroke="#1e3f5a" stroke-width="1.5040415712798472" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="798.2517111945368" y1="479.438089984083" x2="754.1037149985743" y2="570.5775051620274"></line><line stroke="#38bdf8" stroke-width="1.12725815878402" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="798.2517111945368" y1="479.438089984083" x2="858.0234871232745" y2="424.2617189649999"></line><line stroke="#1e3a4a" stroke-width="2.007601231047964" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="798.2517111945368" y1="479.438089984083" x2="658.9175141921899" y2="412.89907221005365"></line><line stroke="#1e3f5a" stroke-width="0.6285362688076458" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="329.01335475799095" y1="437.60539298708653" x2="445.39956168374897" y2="383.1008088272617"></line><line stroke="#38bdf8" stroke-width="1.8617096321488944" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="329.01335475799095" y1="437.60539298708653" x2="380.00732380576056" y2="505.9666277258166"></line><line stroke="#1e3a4a" stroke-width="1.8733336366059918" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="329.01335475799095" y1="437.60539298708653" x2="246.34369865714342" y2="381.98365419044006"></line><line stroke="#1e3f5a" stroke-width="1.408353778351279" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="329.01335475799095" y1="437.60539298708653" x2="457.85087172862654" y2="498.40327936819267"></line><line stroke="#1e3f5a" stroke-width="1.4643079919220623" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.2999819252091" y1="510.5644804369375" x2="765.4459710347816" y2="529.5365898223438"></line><line stroke="#38bdf8" stroke-width="1.3566859574536192" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.2999819252091" y1="510.5644804369375" x2="609.7856706883729" y2="470.14210377237475"></line><line stroke="#1e3a4a" stroke-width="1.2830367383247547" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.2999819252091" y1="510.5644804369375" x2="628.6887497852189" y2="604.6664406533821"></line><line stroke="#1e3f5a" stroke-width="1.1220250754048526" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.2999819252091" y1="510.5644804369375" x2="766.2158109548885" y2="398.689838636173"></line><line stroke="#38bdf8" stroke-width="0.7360442734080187" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.2999819252091" y1="510.5644804369375" x2="801.573452340537" y2="542.8885413366817"></line><line stroke="#1e3f5a" stroke-width="1.429845986652889" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="542.2216430035758" y1="575.388017713222" x2="660.7695551958493" y2="508.3246646803004"></line><line stroke="#38bdf8" stroke-width="1.763445274718944" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="542.2216430035758" y1="575.388017713222" x2="517.1701575629156" y2="509.69271620935206"></line><line stroke="#1e3a4a" stroke-width="1.6531090105060733" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="542.2216430035758" y1="575.388017713222" x2="513.7783397162622" y2="673.8496694760671"></line><line stroke="#1e3f5a" stroke-width="2.1393446875198645" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="542.2216430035758" y1="575.388017713222" x2="511.47102480515827" y2="433.6010055107934"></line><line stroke="#1e3f5a" stroke-width="1.0712709764465258" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="690.0266318197504" y1="282.739388654923" x2="556.9730006608756" y2="377.8106559082528"></line><line stroke="#38bdf8" stroke-width="1.60013967419965" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="690.0266318197504" y1="282.739388654923" x2="587.2368528306883" y2="322.6064316404506"></line><line stroke="#1e3a4a" stroke-width="1.6111232060925111" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="690.0266318197504" y1="282.739388654923" x2="700.1078494485312" y2="393.3527675352126"></line><line stroke="#1e3f5a" stroke-width="1.4503171477320562" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="690.0266318197504" y1="282.739388654923" x2="727.3033260014777" y2="358.690820500209"></line><line stroke="#38bdf8" stroke-width="1.6536865300493833" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="690.0266318197504" y1="282.739388654923" x2="642.2729700874014" y2="277.03437754431206"></line><line stroke="#1e3f5a" stroke-width="1.9297060396502665" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.6933012184418" y1="662.4853263346589" x2="644.2488079871528" y2="575.7371877602418"></line><line stroke="#38bdf8" stroke-width="1.3625555215454836" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.6933012184418" y1="662.4853263346589" x2="752.8071755265902" y2="771.8165481703617"></line><line stroke="#1e3a4a" stroke-width="1.8950959985462483" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="707.6933012184418" y1="662.4853263346589" x2="754.1037149985743" y2="570.5775051620274"></line><line stroke="#1e3f5a" stroke-width="0.8145456497353659" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="453.71664617899637" y1="301.16932046216914" x2="576.9745770083031" y2="433.2410318275608"></line><line stroke="#38bdf8" stroke-width="2.140139309391531" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="453.71664617899637" y1="301.16932046216914" x2="515.8799720809257" y2="242.40663621075785"></line><line stroke="#1e3a4a" stroke-width="1.4209119783933564" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="453.71664617899637" y1="301.16932046216914" x2="445.39956168374897" y2="383.1008088272617"></line><line stroke="#38bdf8" stroke-width="1.1584664653022543" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="644.2488079871528" y1="575.7371877602418" x2="754.1037149985743" y2="570.5775051620274"></line><line stroke="#38bdf8" stroke-width="1.1525567130865872" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="691.071664480076" y1="333.5522776943882" x2="766.2158109548885" y2="398.689838636173"></line><line stroke="#1e3f5a" stroke-width="0.9988456762551912" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="858.0234871232745" y1="424.2617189649999" x2="700.1078494485312" y2="393.3527675352126"></line><line stroke="#38bdf8" stroke-width="0.7161101579168596" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="801.573452340537" y1="542.8885413366817" x2="660.7695551958493" y2="508.3246646803004"></line><line stroke="#a78bfa" stroke-width="0.5988633271470354" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="628.6887497852189" y1="604.6664406533821" x2="513.7783397162622" y2="673.8496694760671"></line><line stroke="#1e3f5a" stroke-width="1.3005601879327329" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="644.2488079871528" y1="575.7371877602418" x2="609.7856706883729" y2="470.14210377237475"></line><line stroke="#a78bfa" stroke-width="1.1179941286914297" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="660.7695551958493" y1="508.3246646803004" x2="644.2488079871528" y2="575.7371877602418"></line><line stroke="#38bdf8" stroke-width="0.7750737798308828" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="765.4459710347816" y1="529.5365898223438" x2="644.2488079871528" y2="575.7371877602418"></line><line stroke="#1e3f5a" stroke-width="1.433340737206227" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="556.9730006608756" y1="377.8106559082528" x2="445.39956168374897" y2="383.1008088272617"></line><line stroke="#a78bfa" stroke-width="1.3388631792421668" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="691.071664480076" y1="333.5522776943882" x2="642.2729700874014" y2="277.03437754431206"></line><line stroke="#1e3f5a" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="660.7695551958493" y1="508.3246646803004" x2="457.85087172862654" y2="498.40327936819267"></line><line stroke="#38bdf8" stroke-width="1.5162020826061342" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="576.9745770083031" y1="433.2410318275608" x2="644.2488079871528" y2="575.7371877602418"></line><line stroke="#1e3f5a" stroke-width="1.5761538130118664" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="566.4425819909418" y1="490.25363129496" x2="464.0155127249235" y2="416.6412418068255"></line><line stroke="#38bdf8" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="445.39956168374897" y1="383.1008088272617" x2="609.7856706883729" y2="470.14210377237475"></line><line stroke="#1e3f5a" stroke-width="0.9783397713404094" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="644.2488079871528" y1="575.7371877602418" x2="765.4459710347816" y2="529.5365898223438"></line><line stroke="#a78bfa" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="380.00732380576056" y1="505.9666277258166" x2="464.0155127249235" y2="416.6412418068255"></line><line stroke="#38bdf8" stroke-width="0.758887948288592" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="642.2729700874014" y1="277.03437754431206" x2="766.2158109548885" y2="398.689838636173"></line><line stroke="#a78bfa" stroke-width="1.6837625833214254" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="642.2729700874014" y1="277.03437754431206" x2="727.3033260014777" y2="358.690820500209"></line><line stroke="#1e3f5a" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="658.9175141921899" y1="412.89907221005365" x2="517.1701575629156" y2="509.69271620935206"></line><line stroke="#38bdf8" stroke-width="0.9427922585414595" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="556.9730006608756" y1="377.8106559082528" x2="517.1701575629156" y2="509.69271620935206"></line><line stroke="#a78bfa" stroke-width="0.9529836409468263" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="644.2488079871528" y1="575.7371877602418" x2="517.1701575629156" y2="509.69271620935206"></line><line stroke="#1e3f5a" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="511.47102480515827" y1="433.6010055107934" x2="642.2729700874014" y2="277.03437754431206"></line><line stroke="#1e3f5a" stroke-width="1.1834219645294066" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="660.7695551958493" y1="508.3246646803004" x2="576.9745770083031" y2="433.2410318275608"></line><line stroke="#38bdf8" stroke-width="1.323442725883473" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="700.1078494485312" y1="393.3527675352126" x2="766.2158109548885" y2="398.689838636173"></line><line stroke="#1e3f5a" stroke-width="1.0023794067758802" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="566.4425819909418" y1="490.25363129496" x2="700.1078494485312" y2="393.3527675352126"></line><line stroke="#38bdf8" stroke-width="0.6600722148300119" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="691.071664480076" y1="333.5522776943882" x2="609.7856706883729" y2="470.14210377237475"></line><line stroke="#38bdf8" stroke-width="0.8410350983064474" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="609.7856706883729" y1="470.14210377237475" x2="644.2488079871528" y2="575.7371877602418"></line><line stroke="#a78bfa" stroke-width="1.0352563430835147" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="566.4425819909418" y1="490.25363129496" x2="511.47102480515827" y2="433.6010055107934"></line><line stroke="#a78bfa" stroke-width="1.2806512369777103" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="517.1701575629156" y1="509.69271620935206" x2="380.00732380576056" y2="505.9666277258166"></line><line stroke="#38bdf8" stroke-width="1.2895613837879794" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="766.2158109548885" y1="398.689838636173" x2="765.4459710347816" y2="529.5365898223438"></line><line stroke="#1e3f5a" stroke-width="0.5859085120479983" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="766.2158109548885" y1="398.689838636173" x2="660.7695551958493" y2="508.3246646803004"></line><line stroke="#a78bfa" stroke-width="1.0073601935147993" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="691.071664480076" y1="333.5522776943882" x2="587.2368528306883" y2="322.6064316404506"></line><line stroke="#1e3f5a" stroke-width="0.6177275275575222" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="464.0155127249235" y1="416.6412418068255" x2="587.2368528306883" y2="322.6064316404506"></line><line stroke="#1e3f5a" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="517.1701575629156" y1="509.69271620935206" x2="421.2941938767897" y2="622.1106201747264"></line><line stroke="#1e3f5a" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="556.9730006608756" y1="377.8106559082528" x2="517.1701575629156" y2="509.69271620935206"></line><line stroke="#1e3f5a" stroke-width="0.6386915435326045" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="658.9175141921899" y1="412.89907221005365" x2="642.2729700874014" y2="277.03437754431206"></line><line stroke="#38bdf8" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="801.573452340537" y1="542.8885413366817" x2="858.0234871232745" y2="424.2617189649999"></line><line stroke="#a78bfa" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-bidirectional)" opacity="0.7" style="cursor: pointer;" x1="727.3033260014777" y1="358.690820500209" x2="754.1037149985743" y2="570.5775051620274"></line><line stroke="#38bdf8" stroke-width="0.5943095081227576" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="566.4425819909418" y1="490.25363129496" x2="660.7695551958493" y2="508.3246646803004"></line><line stroke="#1e3f5a" stroke-width="0.5" stroke-opacity="0.7" marker-end="url(#arrow-forward)" opacity="0.7" style="cursor: pointer;" x1="609.7856706883729" y1="470.14210377237475" x2="700.1078494485312" y2="393.3527675352126"></line></g><g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(628.6887497852189,604.6664406533821)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Codex should use Flux …</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(421.2941938767897,622.1106201747264)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">User prefers dark mode…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(752.8071755265902,771.8165481703617)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Project uses Python 3.…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(513.7783397162622,673.8496694760671)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Flux Memory supports g…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(457.85087172862654,498.40327936819267)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Dashboard redesign tar…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(515.8799720809257,242.40663621075785)"><circle r="8" fill="#0e7490" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Force-directed graphs …</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(700.1078494485312,393.3527675352126)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Health signals track s…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(766.2158109548885,398.689838636173)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Conduit weights decay …</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(691.071664480076,333.5522776943882)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Grain promotion requir…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(754.1037149985743,570.5775051620274)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Shortcut creation impr…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(511.47102480515827,433.6010055107934)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Embedding generation i…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(464.0155127249235,416.6412418068255)"><circle r="8" fill="#0e7490" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">REST API runs on port …</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(445.39956168374897,383.1008088272617)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Retrieval success rate…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(727.3033260014777,358.690820500209)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Dormant grains are can…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(801.573452340537,542.8885413366817)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Feedback compliance dr…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(765.4459710347816,529.5365898223438)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Entry nodes act as fea…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(858.0234871232745,424.2617189649999)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Bidirectional conduits…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(566.4425819909418,490.25363129496)"><circle r="8" fill="#0e7490" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Core decay class persi…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(660.7695551958493,508.3246646803004)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Highway formation mark…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(380.00732380576056,505.9666277258166)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Context spread measure…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(642.2729700874014,277.03437754431206)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Orphan rate tracks dis…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(556.9730006608756,377.8106559082528)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Avg weight drop signal…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(609.7856706883729,470.14210377237475)"><circle r="10" fill="#e0f2fe" fill-opacity="0.9" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Fallback trigger indic…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(658.9175141921899,412.89907221005365)"><circle r="8" fill="#0e7490" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Promotion events mark …</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(644.2488079871528,575.7371877602418)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Avg hops per retrieval…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(517.1701575629156,509.69271620935206)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Conduit dissolution cl…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(246.34369865714342,381.98365419044006)"><circle r="8" fill="#22d3ee" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="12" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Working memory grains …</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(576.9745770083031,433.2410318275608)"><circle r="10" fill="#1e2d40" fill-opacity="0.4" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Ephemeral grains are s…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(587.2368528306883,322.6064316404506)"><circle r="10" fill="#1e2d40" fill-opacity="0.4" stroke="#7dd3fc" stroke-width="1.5"></circle><circle r="14" fill="none" stroke="#22d3ee" stroke-opacity="0.15" stroke-width="3"></circle><text x="14" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">Weight threshold filte…</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(677.3017543299637,443.453260972379)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">user</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(433.4545857512053,570.1429316463693)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">system</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(619.4030946643481,330.12741825586625)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">codex</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(798.2517111945368,479.438089984083)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">flux_mcp</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(329.01335475799095,437.60539298708653)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">retrieval</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(707.2999819252091,510.5644804369375)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">feedback</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(542.2216430035758,575.388017713222)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">dashboard</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(690.0266318197504,282.739388654923)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">memory</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(707.6933012184418,662.4853263346589)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">context</text></g><g class="graph-node" opacity="1" style="cursor: pointer;" transform="translate(453.71664617899637,301.16932046216914)"><circle r="6" fill="#7c3aed" fill-opacity="0.9" stroke="transparent" stroke-width="1.5"></circle><text x="10" y="4" fill="#8899b0" font-size="9px" font-family="JetBrains Mono, monospace" pointer-events="none">session</text></g></g></g></svg>
+        <div id="graph-stats">nodes: <span id="gs-nodes">39</span> · edges: <span id="gs-edges">79</span></div>
+        <div id="graph-overlay">
+          <div class="legend-item"><div class="legend-dot" style="background:#22d3ee"></div>Grain (working)</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#e0f2fe"></div>Grain (core)</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#a78bfa"></div>Entry</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#334155"></div>Dormant</div>
+        </div>
+        <div id="no-data-msg" style="display: none;">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.4"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12" stroke-opacity="0.7"></line><line x1="12" y1="16" x2="12.01" y2="16" stroke-opacity="0.7"></line></svg>
+          No graph data
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT PANEL -->
+    <div id="right-panel">
+
+      <!-- INSPECTOR -->
+      <div class="rpanel-section">
+        <div class="rpanel-header" onclick="toggleSection('inspector')">
+          <div class="rpanel-header-left">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65" stroke-opacity="0.7"></line></svg>
+            <span class="rpanel-title">Inspector</span>
+          </div>
+          <svg class="rpanel-chevron open" id="chev-inspector" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+        </div>
+        <div class="rpanel-body" id="body-inspector">
+          <div id="inspector-empty" style="">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.3"><rect x="3" y="3" width="18" height="18" rx="2"></rect><line x1="9" y1="9" x2="15" y2="15" stroke-opacity="0.7"></line><line x1="15" y1="9" x2="9" y2="15" stroke-opacity="0.7"></line></svg>
+            <div style="margin-top:8px">Click a node or edge<br>to inspect its properties</div>
+          </div>
+          <div id="inspector-content" style="display: none;">
+      <div style="margin-bottom:10px">
+        <div class="inspector-label" style="font-size:11px">session…</div>
+        <div style="color:var(--text-dim);font-size:10px;margin:3px 0">↓</div>
+        <div class="inspector-label" style="font-size:11px">Retrieval success rate measures useful m…</div>
+      </div>
+      <div class="inspector-rows">
+        <div class="inspector-row"><span class="ir-key">Weight</span><span class="ir-val">0.5800</span></div>
+        <div class="inspector-row"><span class="ir-key">Eff. weight</span><span class="ir-val">0.5684</span></div>
+        <div class="inspector-row"><span class="ir-key">Direction</span><span class="ir-val"><span class="tag tag-dim">forward</span></span></div>
+        <div class="inspector-row"><span class="ir-key">Decay class</span><span class="ir-val"><span class="tag tag-dim">ephemeral</span></span></div>
+        <div class="inspector-row"><span class="ir-key">Use count</span><span class="ir-val">18</span></div>
+        <div class="inspector-row"><span class="ir-key">Edge type</span><span class="ir-val"><span class="tag tag-dim">earned</span></span></div>
+      </div></div>
+        </div>
+      </div>
+
+      <!-- WARNINGS -->
+      <div class="rpanel-section">
+        <div class="rpanel-header" onclick="toggleSection('warnings')">
+          <div class="rpanel-header-left">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13" stroke-opacity="0.7"></line><line x1="12" y1="17" x2="12.01" y2="17" stroke-opacity="0.7"></line></svg>
+            <span class="rpanel-title">Warnings</span>
+            <span class="rpanel-count warn" id="warn-count">2</span>
+          </div>
+          <svg class="rpanel-chevron open" id="chev-warnings" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+        </div>
+        <div class="rpanel-body" id="body-warnings">
+          <div id="warnings-list" style="color:var(--text-dim);font-size:11px">
+      <div class="warning-card">
+        <div class="warning-signal">feedback_compliance_rate</div>
+        <div class="warning-msg">Main AI is not calling flux_feedback reliably. Prompt engineering issue.</div>
+        <div class="warning-val">Value: 0 · Range: &gt;= 0.8 · Severity: WARNING</div>
+      </div>
+      <div class="warning-card">
+        <div class="warning-signal">fallback_trigger_rate</div>
+        <div class="warning-msg">All retrievals are using fallback. Check retrieval routing logic.</div>
+        <div class="warning-val">Value: 1 · Range: &lt; 0.3 · Severity: WARNING</div>
+      </div></div>
+        </div>
+      </div>
+
+      <!-- HEALTH SIGNALS -->
+      <div class="rpanel-section">
+        <div class="rpanel-header" onclick="toggleSection('health')">
+          <div class="rpanel-header-left">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+            <span class="rpanel-title">Health Signals</span>
+          </div>
+          <svg class="rpanel-chevron open" id="chev-health" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+        </div>
+        <div class="rpanel-body" id="body-health">
+          <div id="health-table" style="color:var(--text-dim);font-size:11px"><div class="health-group"><div class="health-group-label">Retrieval</div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">retrieval success rate</div>
+        <div class="health-row-val" style="color:var(--text)">74%</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">avg hops per retrieval</div>
+        <div class="health-row-val" style="color:var(--text)">2.10</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--rose)"></div>
+        <div class="health-row-key">fallback trigger rate</div>
+        <div class="health-row-val" style="color:var(--rose)">100%</div>
+      </div></div><div class="health-group"><div class="health-group-label">Feedback</div><div class="health-row">
+        <div class="health-dot" style="background:var(--rose)"></div>
+        <div class="health-row-key">feedback compliance rate</div>
+        <div class="health-row-val" style="color:var(--rose)">0.00</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">promotion events</div>
+        <div class="health-row-val" style="color:var(--text)">3.00</div>
+      </div></div><div class="health-group"><div class="health-group-label">Graph</div><div class="health-row">
+        <div class="health-dot" style="background:var(--rose)"></div>
+        <div class="health-row-key">highway count</div>
+        <div class="health-row-val" style="color:var(--rose)">0.00</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--rose)"></div>
+        <div class="health-row-key">highway growth rate</div>
+        <div class="health-row-val" style="color:var(--rose)">0.00</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">orphan rate</div>
+        <div class="health-row-val" style="color:var(--text)">3%</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">core grain count</div>
+        <div class="health-row-val" style="color:var(--text)">12.00</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">avg conduit weight</div>
+        <div class="health-row-val" style="color:var(--text)">0.39</div>
+      </div></div><div class="health-group"><div class="health-group-label">Decay</div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">dormant grain rate</div>
+        <div class="health-row-val" style="color:var(--text)">2%</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--rose)"></div>
+        <div class="health-row-key">conduit dissolution rate</div>
+        <div class="health-row-val" style="color:var(--rose)">0.00</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--rose)"></div>
+        <div class="health-row-key">avg weight drop on failure</div>
+        <div class="health-row-val" style="color:var(--rose)">0.00</div>
+      </div><div class="health-row">
+        <div class="health-dot" style="background:var(--green)"></div>
+        <div class="health-row-key">shortcut creation rate</div>
+        <div class="health-row-val" style="color:var(--text)">5%</div>
+      </div></div></div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script>
+// ── MOCK DATA ─────────────────────────────────────────────────────────────────
+const MOCK_HEALTH = {"status":"warning","signals":{"highway_count":{"value":0,"healthy":false},"core_grain_count":{"value":12,"healthy":true},"orphan_rate":{"value":0.03,"healthy":true},"avg_conduit_weight":{"value":0.385,"healthy":true},"dormant_grain_rate":{"value":0.02,"healthy":true},"highway_growth_rate":{"value":0,"healthy":false},"shortcut_creation_rate":{"value":0.05,"healthy":true},"conduit_dissolution_rate":{"value":0,"healthy":false},"avg_weight_drop_on_failure":{"value":0,"healthy":false},"promotion_events":{"value":3,"healthy":true},"avg_hops_per_retrieval":{"value":2.1,"healthy":true},"retrieval_success_rate":{"value":0.74,"healthy":true},"fallback_trigger_rate":{"value":1.0,"healthy":false},"feedback_compliance_rate":{"value":0.0,"healthy":false}},"active_warnings":[{"signal":"feedback_compliance_rate","severity":"WARNING","current_value":0.0,"healthy_range":">= 0.8","first_seen":"2026-04-23T13:43:13Z","last_seen":"2026-04-24T03:15:47Z","suggestion":"Main AI is not calling flux_feedback reliably. Prompt engineering issue."},{"signal":"fallback_trigger_rate","severity":"WARNING","current_value":1.0,"healthy_range":"< 0.3","first_seen":"2026-04-23T14:00:00Z","last_seen":"2026-04-24T03:15:47Z","suggestion":"All retrievals are using fallback. Check retrieval routing logic."}],"computed_at":"2026-04-24T03:15:47.162197+05:30"};
+
+const MOCK_GRAPH = (function() {
+  const grainTypes = ['working','working','working','core','core','ephemeral'];
+  const provenances = ['ai_stated','user_stated','inferred','ai_stated'];
+  const labels = [
+    'Codex should use Flux Memory MCP server for persistence',
+    'User prefers dark mode in all interfaces',
+    'Project uses Python 3.11+ for backend services',
+    'Flux Memory supports graph-based knowledge retrieval',
+    'Dashboard redesign targets operational clarity',
+    'Force-directed graphs improve dense node layout',
+    'Health signals track system reliability over time',
+    'Conduit weights decay unless reinforced via feedback',
+    'Grain promotion requires threshold crossing events',
+    'Shortcut creation improves retrieval hop efficiency',
+    'Embedding generation is synchronous at grain creation',
+    'REST API runs on port 7465 separate from dashboard',
+    'Retrieval success rate measures useful memory recall',
+    'Dormant grains are candidates for expiry cleanup',
+    'Feedback compliance drives reinforcement learning loop',
+    'Entry nodes act as feature anchors in the graph',
+    'Bidirectional conduits indicate mutual reinforcement',
+    'Core decay class persists across cleanup passes',
+    'Highway formation marks strongly connected clusters',
+    'Context spread measures grain reachability depth',
+    'Orphan rate tracks disconnected grain percentage',
+    'Avg weight drop signals failed retrieval patterns',
+    'Fallback trigger indicates missing primary routes',
+    'Promotion events mark grain tier advancement',
+    'Avg hops per retrieval measures path efficiency',
+    'Conduit dissolution clears low-weight dead edges',
+    'Working memory grains have intermediate persistence',
+    'Ephemeral grains are short-lived session facts',
+    'Weight threshold filtering removes noise from graph',
+  ];
+  const entryLabels = ['user','system','codex','flux_mcp','retrieval','feedback','dashboard','memory','context','session'];
+  const nodes = [];
+  const links = [];
+  for (let i = 0; i < 29; i++) {
+    nodes.push({id:`grain_${i}`,label:labels[i]||`Grain node ${i}`,node_type:'grain',decay_class:grainTypes[i%grainTypes.length],status:i<27?'active':'dormant',provenance:provenances[i%provenances.length],context_spread:Math.floor(Math.random()*5)});
+  }
+  for (let i = 0; i < 10; i++) {
+    nodes.push({id:`entry_${i}`,label:entryLabels[i],node_type:'entry',feature:entryLabels[i]});
+  }
+  // entry → grain links
+  for (let i = 0; i < 10; i++) {
+    const count = 2 + Math.floor(Math.random()*4);
+    for (let j = 0; j < count; j++) {
+      const gIdx = (i*3+j*7) % 29;
+      const w = 0.2 + Math.random()*0.7;
+      links.push({source:`entry_${i}`,target:`grain_${gIdx}`,weight:w,effective_weight:w*0.98,direction:'forward',decay_class:['working','core','ephemeral'][j%3],use_count:Math.floor(Math.random()*20),edge_type:'earned'});
+    }
+  }
+  // grain → grain links
+  for (let i = 0; i < 40; i++) {
+    const a = Math.floor(Math.random()*29), b = Math.floor(Math.random()*29);
+    if (a!==b) {
+      const w = 0.1 + Math.random()*0.6;
+      links.push({source:`grain_${a}`,target:`grain_${b}`,weight:w,effective_weight:w*0.97,direction:Math.random()>0.8?'bidirectional':'forward',decay_class:['working','core'][Math.floor(Math.random()*2)],use_count:Math.floor(Math.random()*10),edge_type:Math.random()>0.85?'shortcut':'earned'});
+    }
+  }
+  return {directed:true,multigraph:false,stats:{grains:29,active_grains:29,dormant_grains:0,entries:135,conduits:260,embeddings:29},nodes,links};
+})();
+
+// ── STATE ─────────────────────────────────────────────────────────────────────
+let healthData = null, graphData = null;
+let simulation = null, svg = null, g = null, zoom = null;
+let activeFilters = {grain:true, entry:true, active:true, dormant:false};
+let weightThreshold = 0;
+let searchQuery = '';
+let selectedNode = null, selectedEdge = null;
+let simulationPaused = false;
+let autoRefreshTimer = null;
+let isAutoRefresh = false;
+
+// ── FETCH ─────────────────────────────────────────────────────────────────────
+async function fetchAll() {
+  try {
+    const [h, gr] = await Promise.all([
+      fetch('/api/health').then(r => r.json()).catch(() => MOCK_HEALTH),
+      fetch('/api/graph').then(r => r.json()).catch(() => MOCK_GRAPH),
+    ]);
+    healthData = h; graphData = gr;
+  } catch(e) {
+    healthData = MOCK_HEALTH; graphData = MOCK_GRAPH;
+  }
+  renderHealth();
+  renderGraph();
+  document.getElementById('loading').style.display = 'none';
+}
+
+function toggleAutoRefresh() {
+  isAutoRefresh = !isAutoRefresh;
+  const btn = document.getElementById('autorefresh-btn');
+  const lbl = document.getElementById('refresh-interval');
+  btn.classList.toggle('active', isAutoRefresh);
+  lbl.style.display = isAutoRefresh ? '' : 'none';
+  if (isAutoRefresh) {
+    autoRefreshTimer = setInterval(() => { fetchAll(); }, 30000);
+  } else {
+    clearInterval(autoRefreshTimer);
+  }
+}
+
+// ── HEALTH RENDER ─────────────────────────────────────────────────────────────
+function renderHealth() {
+  if (!healthData) return;
+  const h = healthData;
+
+  // Status badge
+  const badge = document.getElementById('status-badge');
+  const pulse = badge.querySelector('.pulse');
+  const statusText = document.getElementById('status-text');
+  badge.className = 'badge-' + h.status;
+  pulse.className = 'pulse pulse-' + (h.status==='healthy'?'green':h.status==='warning'?'amber':'rose');
+  statusText.textContent = h.status.toUpperCase();
+
+  // Computed at
+  const ca = new Date(h.computed_at);
+  document.getElementById('computed-at').textContent = ca.toLocaleTimeString();
+
+  // Metrics strip
+  const s = h.signals;
+  function pct(v) { return (v*100).toFixed(0) + '%'; }
+  const rs = s.retrieval_success_rate?.value ?? 0;
+  const fb = s.fallback_trigger_rate?.value ?? 0;
+  const fc = s.feedback_compliance_rate?.value ?? 0;
+  document.getElementById('m-retrieval').textContent = pct(rs);
+  document.getElementById('m-retrieval').className = 'm-value ' + (rs>=0.7?'c-green':'c-rose');
+  document.getElementById('m-fallback').textContent = pct(fb);
+  document.getElementById('m-fallback').className = 'm-value ' + (fb<0.3?'c-green':fb<0.7?'c-amber':'c-rose');
+  document.getElementById('m-feedback').textContent = pct(fc);
+  document.getElementById('m-feedback').className = 'm-value ' + (fc>=0.8?'c-green':'c-rose');
+
+  // Graph stats from graphData
+  if (graphData?.stats) {
+    const st = graphData.stats;
+    document.getElementById('m-grains').textContent = st.grains ?? '—';
+    document.getElementById('m-entries').textContent = st.entries ?? '—';
+    document.getElementById('m-conduits').textContent = st.conduits ?? '—';
+    document.getElementById('m-embed').textContent = st.embeddings ?? '—';
+  }
+
+  // Warnings
+  const warns = h.active_warnings || [];
+  document.getElementById('warn-count').textContent = warns.length;
+  document.getElementById('warn-count').className = 'rpanel-count' + (warns.length ? ' warn' : '');
+  const wl = document.getElementById('warnings-list');
+  if (!warns.length) {
+    wl.innerHTML = '<div style="color:var(--text-dim);font-size:11px">No active warnings</div>';
+  } else {
+    wl.innerHTML = warns.map(w => `
+      <div class="warning-card">
+        <div class="warning-signal">${w.signal}</div>
+        <div class="warning-msg">${w.suggestion}</div>
+        <div class="warning-val">Value: ${w.current_value} · Range: ${w.healthy_range} · Severity: ${w.severity}</div>
+      </div>`).join('');
+  }
+
+  // Health table
+  const groups = {
+    'Retrieval': ['retrieval_success_rate','avg_hops_per_retrieval','fallback_trigger_rate'],
+    'Feedback': ['feedback_compliance_rate','promotion_events'],
+    'Graph': ['highway_count','highway_growth_rate','orphan_rate','core_grain_count','avg_conduit_weight'],
+    'Decay': ['dormant_grain_rate','conduit_dissolution_rate','avg_weight_drop_on_failure','shortcut_creation_rate'],
+  };
+  let html = '';
+  for (const [group, keys] of Object.entries(groups)) {
+    html += `<div class="health-group"><div class="health-group-label">${group}</div>`;
+    for (const k of keys) {
+      const sig = s[k]; if (!sig) continue;
+      const ok = sig.healthy;
+      const v = sig.value;
+      const display = (v > 0 && v <= 1 && k.includes('rate')) ? (v*100).toFixed(0)+'%' : v.toFixed ? v.toFixed(2) : v;
+      html += `<div class="health-row">
+        <div class="health-dot" style="background:${ok?'var(--green)':'var(--rose)'}"></div>
+        <div class="health-row-key">${k.replace(/_/g,' ')}</div>
+        <div class="health-row-val" style="color:${ok?'var(--text)':'var(--rose)'}">${display}</div>
+      </div>`;
+    }
+    html += '</div>';
+  }
+  document.getElementById('health-table').innerHTML = html;
+}
+
+// ── GRAPH RENDER ──────────────────────────────────────────────────────────────
+function nodeColor(n) {
+  if (n.status === 'dormant') return '#1e2d40';
+  if (n.node_type === 'entry') return '#7c3aed';
+  if (n.decay_class === 'core') return '#e0f2fe';
+  if (n.decay_class === 'ephemeral') return '#0e7490';
+  return '#22d3ee';
+}
+function nodeRadius(n) {
+  if (n.node_type === 'entry') return 6;
+  if (n.decay_class === 'core') return 10;
+  return 8;
+}
+function edgeColor(l) {
+  if (l.direction === 'bidirectional') return '#a78bfa';
+  if (l.decay_class === 'core') return '#38bdf8';
+  if (l.decay_class === 'ephemeral') return '#1e3a4a';
+  return '#1e3f5a';
+}
+
+function getVisibleNodes() {
+  if (!graphData) return [];
+  return graphData.nodes.filter(n => {
+    const typeOk = (n.node_type === 'grain' && activeFilters.grain) || (n.node_type === 'entry' && activeFilters.entry);
+    const statusOk = (n.status === 'active' || !n.status) ? activeFilters.active : (n.status === 'dormant' ? activeFilters.dormant : true);
+    const searchOk = !searchQuery || n.label.toLowerCase().includes(searchQuery) || n.id.includes(searchQuery);
+    return typeOk && statusOk;
+  });
+}
+
+function getVisibleLinks(nodeIds) {
+  if (!graphData) return [];
+  const idSet = new Set(nodeIds);
+  return graphData.links.filter(l => {
+    const sid = typeof l.source === 'object' ? l.source.id : l.source;
+    const tid = typeof l.target === 'object' ? l.target.id : l.target;
+    return idSet.has(sid) && idSet.has(tid) && (l.effective_weight ?? l.weight ?? 0) >= weightThreshold;
+  });
+}
+
+function renderGraph() {
+  const container = document.getElementById('graph-container');
+  const W = container.clientWidth, H = container.clientHeight;
+  d3.select('#graph-svg').selectAll('*').remove();
+
+  if (!graphData || !graphData.nodes.length) {
+    document.getElementById('no-data-msg').style.display = 'flex';
+    return;
+  }
+  document.getElementById('no-data-msg').style.display = 'none';
+
+  const visNodes = getVisibleNodes();
+  const visLinks = getVisibleLinks(visNodes.map(n => n.id));
+
+  document.getElementById('gs-nodes').textContent = visNodes.length;
+  document.getElementById('gs-edges').textContent = visLinks.length;
+
+  // Deep copy so D3 can mutate
+  const nodes = visNodes.map(n => ({...n}));
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  const links = visLinks.map(l => ({
+    ...l,
+    source: nodeMap.get(typeof l.source==='object'?l.source.id:l.source) || l.source,
+    target: nodeMap.get(typeof l.target==='object'?l.target.id:l.target) || l.target,
+  })).filter(l => l.source && l.target);
+
+  svg = d3.select('#graph-svg').attr('width', W).attr('height', H);
+
+  // Defs: arrowheads
+  const defs = svg.append('defs');
+  ['forward','bidirectional','selected'].forEach(t => {
+    defs.append('marker').attr('id','arrow-'+t)
+      .attr('viewBox','0 -4 8 8').attr('refX',14).attr('refY',0)
+      .attr('markerWidth',6).attr('markerHeight',6).attr('orient','auto')
+      .append('path').attr('d','M0,-4L8,0L0,4').attr('fill',t==='selected'?'#22d3ee':t==='bidirectional'?'#7c3aed':'#1e3f5a');
+  });
+
+  zoom = d3.zoom().scaleExtent([0.15, 4]).on('zoom', e => g.attr('transform', e.transform));
+  svg.call(zoom);
+  g = svg.append('g');
+
+  const link = g.append('g').selectAll('line').data(links).enter().append('line')
+    .attr('stroke', d => edgeColor(d))
+    .attr('stroke-width', d => Math.max(0.5, (d.effective_weight ?? 0.3) * 2.5))
+    .attr('stroke-opacity', 0.7)
+    .attr('marker-end', d => `url(#arrow-${d.direction==='bidirectional'?'bidirectional':'forward'})`)
+    .style('cursor','pointer')
+    .on('mouseenter', (event, d) => showEdgeTooltip(event, d))
+    .on('mousemove', moveTooltip)
+    .on('mouseleave', hideTooltip)
+    .on('click', (event, d) => { event.stopPropagation(); selectEdge(d); });
+
+  const node = g.append('g').selectAll('g').data(nodes).enter().append('g')
+    .attr('class','graph-node')
+    .style('cursor','pointer')
+    .call(d3.drag().on('start', dragStart).on('drag', dragged).on('end', dragEnd))
+    .on('mouseenter', (event, d) => showNodeTooltip(event, d))
+    .on('mousemove', moveTooltip)
+    .on('mouseleave', hideTooltip)
+    .on('click', (event, d) => { event.stopPropagation(); selectNode(d); });
+
+  node.append('circle')
+    .attr('r', d => nodeRadius(d))
+    .attr('fill', d => nodeColor(d))
+    .attr('fill-opacity', d => d.status==='dormant' ? 0.4 : 0.9)
+    .attr('stroke', d => d.decay_class==='core' ? '#7dd3fc' : 'transparent')
+    .attr('stroke-width', 1.5);
+
+  // Glow for core grains
+  node.filter(d => d.decay_class==='core').append('circle')
+    .attr('r', d => nodeRadius(d) + 4)
+    .attr('fill', 'none')
+    .attr('stroke', '#22d3ee')
+    .attr('stroke-opacity', 0.15)
+    .attr('stroke-width', 3);
+
+  node.append('text')
+    .text(d => d.node_type==='entry' ? d.label : d.label.slice(0,22) + (d.label.length>22?'…':''))
+    .attr('x', d => nodeRadius(d)+4)
+    .attr('y', 4)
+    .attr('fill', '#8899b0')
+    .attr('font-size', '9px')
+    .attr('font-family', 'JetBrains Mono, monospace')
+    .attr('pointer-events', 'none');
+
+  simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(links).id(d=>d.id).distance(d => {
+      const w = d.effective_weight ?? 0.3;
+      return 60 + (1-w)*60;
+    }).strength(0.4))
+    .force('charge', d3.forceManyBody().strength(-180).distanceMax(300))
+    .force('center', d3.forceCenter(W/2, H/2))
+    .force('collision', d3.forceCollide(d => nodeRadius(d)+8))
+    .on('tick', () => {
+      link
+        .attr('x1', d => d.source.x).attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
+      node.attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+
+  // Click away to deselect
+  svg.on('click', () => { deselectAll(); });
+
+  // Animate in
+  node.attr('opacity', 0).transition().duration(400).delay((d,i)=>i*8).attr('opacity',1);
+  link.attr('opacity', 0).transition().duration(300).delay(200).attr('opacity', 0.7);
+
+  if (simulationPaused) simulation.stop();
+}
+
+function dragStart(event, d) { if (!event.active) simulation?.alphaTarget(0.3).restart(); d.fx=d.x; d.fy=d.y; }
+function dragged(event, d) { d.fx=event.x; d.fy=event.y; }
+function dragEnd(event, d) { if (!event.active) simulation?.alphaTarget(0); d.fx=null; d.fy=null; }
+
+function toggleSimulation() {
+  simulationPaused = !simulationPaused;
+  const icon = document.getElementById('pause-icon');
+  if (simulationPaused) {
+    simulation?.stop();
+    icon.innerHTML = '<polygon points="5 3 19 12 5 21 5 3"/>';
+  } else {
+    simulation?.alphaTarget(0.1).restart();
+    setTimeout(()=>simulation?.alphaTarget(0), 2000);
+    icon.innerHTML = '<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>';
+  }
+}
+
+function resetView() {
+  if (!svg || !zoom) return;
+  svg.transition().duration(500).call(zoom.transform, d3.zoomIdentity);
+}
+
+// ── TOOLTIP ───────────────────────────────────────────────────────────────────
+const tt = document.getElementById('tooltip');
+function showTooltip(x, y, title, rows) {
+  document.getElementById('tt-title').textContent = title;
+  document.getElementById('tt-body').innerHTML = rows.map(([k,v])=>
+    `<div class="tt-row"><span class="tt-key">${k}</span><span class="tt-val">${v}</span></div>`
+  ).join('');
+  tt.style.opacity = '1';
+  positionTooltip(x, y);
+}
+function positionTooltip(x, y) {
+  const r = tt.getBoundingClientRect();
+  tt.style.left = (x + 14 + r.width > window.innerWidth ? x - r.width - 10 : x + 14) + 'px';
+  tt.style.top = Math.min(y - 10, window.innerHeight - r.height - 10) + 'px';
+}
+function moveTooltip(event) { positionTooltip(event.clientX, event.clientY); }
+function hideTooltip() { tt.style.opacity = '0'; }
+function showNodeTooltip(event, d) {
+  showTooltip(event.clientX, event.clientY, d.label.slice(0,60), [
+    ['type', d.node_type],
+    ...(d.decay_class ? [['decay', d.decay_class]] : []),
+    ...(d.status ? [['status', d.status]] : []),
+    ...(d.provenance ? [['provenance', d.provenance]] : []),
+    ...(d.context_spread !== undefined ? [['ctx spread', d.context_spread]] : []),
+  ]);
+}
+function showEdgeTooltip(event, d) {
+  const sid = typeof d.source==='object'?d.source.id:d.source;
+  const tid = typeof d.target==='object'?d.target.id:d.target;
+  showTooltip(event.clientX, event.clientY, `${sid.slice(0,10)}… → ${tid.slice(0,10)}…`, [
+    ['weight', (d.weight??0).toFixed(4)],
+    ['eff. weight', (d.effective_weight??0).toFixed(4)],
+    ['direction', d.direction],
+    ['decay', d.decay_class??'—'],
+    ['use count', d.use_count??0],
+    ['edge type', d.edge_type??'—'],
+  ]);
+}
+
+// ── SELECTION / INSPECTOR ─────────────────────────────────────────────────────
+function deselectAll() {
+  selectedNode = null; selectedEdge = null;
+  d3.selectAll('.graph-node circle').attr('stroke', d=>d.decay_class==='core'?'#7dd3fc':'transparent').attr('stroke-width', 1.5);
+  d3.selectAll('line').attr('stroke-opacity', 0.7);
+  d3.selectAll('.graph-node').attr('opacity', 1);
+  document.getElementById('inspector-empty').style.display = '';
+  document.getElementById('inspector-content').style.display = 'none';
+}
+
+function selectNode(d) {
+  selectedNode = d; selectedEdge = null;
+  // Highlight neighborhood
+  const neighborIds = new Set([d.id]);
+  d3.selectAll('line').each(function(l) {
+    const sid = typeof l.source==='object'?l.source.id:l.source;
+    const tid = typeof l.target==='object'?l.target.id:l.target;
+    if (sid===d.id || tid===d.id) { neighborIds.add(sid); neighborIds.add(tid); }
+  });
+  d3.selectAll('.graph-node').attr('opacity', n => neighborIds.has(n.id) ? 1 : 0.15);
+  d3.selectAll('line').attr('stroke-opacity', l => {
+    const sid = typeof l.source==='object'?l.source.id:l.source;
+    const tid = typeof l.target==='object'?l.target.id:l.target;
+    return (sid===d.id||tid===d.id) ? 1 : 0.05;
+  });
+  d3.selectAll('.graph-node circle').attr('stroke', n => n.id===d.id ? '#22d3ee' : n.decay_class==='core'?'#7dd3fc':'transparent').attr('stroke-width', n => n.id===d.id ? 2.5 : 1.5);
+  renderInspector(d, 'node');
+}
+
+function selectEdge(d) {
+  selectedEdge = d; selectedNode = null;
+  deselectAll();
+  renderInspector(d, 'edge');
+}
+
+function tagHtml(v, positive) {
+  const cls = v==='active'||v==='core'?'cyan':v==='entry'?'violet':v==='dormant'||positive===false?'rose':v==='working'?'cyan':v==='ephemeral'?'dim':'dim';
+  return `<span class="tag tag-${cls}">${v}</span>`;
+}
+
+function renderInspector(d, type) {
+  document.getElementById('inspector-empty').style.display = 'none';
+  const el = document.getElementById('inspector-content');
+  el.style.display = '';
+  if (type === 'node') {
+    const color = nodeColor(d);
+    const isEntry = d.node_type==='entry';
+    el.innerHTML = `
+      <div class="inspector-node-header">
+        <div class="inspector-icon" style="background:${color}22;border:1px solid ${color}44">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="${color}"><circle cx="12" cy="12" r="${isEntry?6:8}"/></svg>
+        </div>
+        <div>
+          <div class="inspector-label">${d.label}</div>
+          <div class="inspector-type">${d.node_type}${d.decay_class?' · '+d.decay_class:''}</div>
+        </div>
+      </div>
+      <div class="inspector-rows">
+        <div class="inspector-row"><span class="ir-key">ID</span><span class="ir-val" style="font-size:10px">${d.id}</span></div>
+        <div class="inspector-row"><span class="ir-key">Type</span><span class="ir-val">${tagHtml(d.node_type)}</span></div>
+        ${d.status?`<div class="inspector-row"><span class="ir-key">Status</span><span class="ir-val">${tagHtml(d.status)}</span></div>`:''}
+        ${d.decay_class?`<div class="inspector-row"><span class="ir-key">Decay class</span><span class="ir-val">${tagHtml(d.decay_class)}</span></div>`:''}
+        ${d.provenance?`<div class="inspector-row"><span class="ir-key">Provenance</span><span class="ir-val"><span class="tag tag-dim">${d.provenance}</span></span></div>`:''}
+        ${d.context_spread!==undefined?`<div class="inspector-row"><span class="ir-key">Context spread</span><span class="ir-val">${d.context_spread}</span></div>`:''}
+        ${d.feature?`<div class="inspector-row"><span class="ir-key">Feature</span><span class="ir-val">${d.feature}</span></div>`:''}
+      </div>`;
+  } else {
+    const sid = typeof d.source==='object'?d.source.id:d.source;
+    const tid = typeof d.target==='object'?d.target.id:d.target;
+    const sl = typeof d.source==='object'?d.source.label:sid;
+    const tl = typeof d.target==='object'?d.target.label:tid;
+    el.innerHTML = `
+      <div style="margin-bottom:10px">
+        <div class="inspector-label" style="font-size:11px">${(sl||sid).slice(0,40)}…</div>
+        <div style="color:var(--text-dim);font-size:10px;margin:3px 0">↓</div>
+        <div class="inspector-label" style="font-size:11px">${(tl||tid).slice(0,40)}…</div>
+      </div>
+      <div class="inspector-rows">
+        <div class="inspector-row"><span class="ir-key">Weight</span><span class="ir-val">${(d.weight??0).toFixed(4)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Eff. weight</span><span class="ir-val">${(d.effective_weight??0).toFixed(4)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Direction</span><span class="ir-val">${tagHtml(d.direction)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Decay class</span><span class="ir-val">${tagHtml(d.decay_class??'working')}</span></div>
+        <div class="inspector-row"><span class="ir-key">Use count</span><span class="ir-val">${d.use_count??0}</span></div>
+        <div class="inspector-row"><span class="ir-key">Edge type</span><span class="ir-val"><span class="tag tag-dim">${d.edge_type??'earned'}</span></span></div>
+      </div>`;
+  }
+}
+
+// ── FILTERS / SEARCH ──────────────────────────────────────────────────────────
+function toggleFilter(key) {
+  activeFilters[key] = !activeFilters[key];
+  const btn = document.getElementById('f-'+key);
+  if (btn) btn.classList.toggle('active', activeFilters[key]);
+  renderGraph();
+}
+function onSearch(val) {
+  searchQuery = val.toLowerCase().trim();
+  if (searchQuery) {
+    // Highlight matching nodes
+    d3.selectAll('.graph-node').attr('opacity', d => {
+      return d.label.toLowerCase().includes(searchQuery) || d.id.includes(searchQuery) ? 1 : 0.1;
+    });
+  } else {
+    d3.selectAll('.graph-node').attr('opacity', 1);
+  }
+}
+function onWeightChange(val) {
+  weightThreshold = parseFloat(val);
+  document.getElementById('weight-val').textContent = parseFloat(val).toFixed(2);
+  renderGraph();
+}
+
+// ── PANEL COLLAPSE ────────────────────────────────────────────────────────────
+function toggleSection(id) {
+  const body = document.getElementById('body-'+id);
+  const chev = document.getElementById('chev-'+id);
+  const visible = body.style.display !== 'none';
+  body.style.display = visible ? 'none' : '';
+  if (chev) chev.classList.toggle('open', !visible);
+}
+
+// ── INIT ──────────────────────────────────────────────────────────────────────
+window.addEventListener('load', () => {
+  fetchAll();
+  window.addEventListener('resize', () => { if (graphData) renderGraph(); });
+});
+</script>
+
+
+<span id="PING_IFRAME_FORM_DETECTION" style="display: none;"></span></body></html>

--- a/design/mobile-preview/Mobile Preview - live.html
+++ b/design/mobile-preview/Mobile Preview - live.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<title>Mobile Preview — Flux Dashboard</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #060810;
+    min-height: 100vh;
+    font-family: system-ui, sans-serif;
+    padding: 32px 24px 48px;
+    overflow-x: auto;
+  }
+
+  h1 {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.8px;
+    color: #3a4255; text-align: center; margin-bottom: 32px;
+  }
+
+  .devices-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 40px;
+    flex-wrap: wrap;
+  }
+
+  .device { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .device-label { font-size: 10px; color: #3a4255; text-transform: uppercase; letter-spacing: 0.6px; }
+  .device-sub { font-size: 10px; color: #22253a; }
+
+  /* ── IPHONE AIR FRAME ── */
+  .iphone-air {
+    width: 280px;
+    background: #1c1c1e;
+    border-radius: 50px;
+    border: 1.5px solid #2c2c2e;
+    box-shadow:
+      0 0 0 1px #0a0a0c,
+      inset 0 0 0 1px #3a3a3e,
+      0 40px 80px rgba(0,0,0,0.9),
+      0 0 40px rgba(34,211,238,0.04);
+    position: relative;
+    padding: 14px;
+  }
+  .iphone-air .dynamic-island {
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    width: 90px; height: 30px;
+    background: #000; border-radius: 20px; z-index: 10;
+  }
+  .iphone-air .screen {
+    width: 100%; height: 580px;
+    border-radius: 38px; overflow: hidden;
+    background: #080a0e;
+    position: relative;
+  }
+  .iphone-air .screen iframe {
+    width: 390px; height: 844px;
+    border: none; display: block;
+    transform: scale(0.642);
+    transform-origin: top left;
+    pointer-events: auto;
+  }
+  .iphone-air .home-bar {
+    width: 80px; height: 4px; border-radius: 2px;
+    background: rgba(255,255,255,0.12);
+    margin: 10px auto 0;
+  }
+  /* Side buttons */
+  .iphone-air::before {
+    content: '';
+    position: absolute; right: -3px; top: 120px;
+    width: 3px; height: 60px;
+    background: #2a2a2c; border-radius: 0 3px 3px 0;
+  }
+  .iphone-air::after {
+    content: '';
+    position: absolute; left: -3px; top: 100px;
+    width: 3px; height: 100px;
+    background: #2a2a2c; border-radius: 3px 0 0 3px;
+    box-shadow: 0 50px 0 #2a2a2c, 0 -50px 0 #2a2a2c;
+  }
+
+  /* ── RAZR UNFOLDED FRAME ── */
+  .razr-open {
+    width: 258px;
+    background: #18181a;
+    border-radius: 30px;
+    border: 1.5px solid #2c2c2e;
+    box-shadow:
+      0 0 0 1px #0a0a0c,
+      inset 0 0 0 1px #303032,
+      0 40px 80px rgba(0,0,0,0.9);
+    position: relative;
+    padding: 12px;
+    /* Hinge seam */
+  }
+  .razr-open .hinge-seam {
+    position: absolute; left: 12px; right: 12px;
+    top: 50%; transform: translateY(-50%);
+    height: 6px;
+    background: #0f0f11;
+    border-top: 1px solid #222224;
+    border-bottom: 1px solid #222224;
+    z-index: 20;
+    pointer-events: none;
+  }
+  .razr-open .punch-hole {
+    position: absolute; top: 18px; left: 50%;
+    transform: translateX(-50%);
+    width: 10px; height: 10px;
+    background: #000; border-radius: 50%; z-index: 10;
+  }
+  .razr-open .screen {
+    width: 100%; height: 540px;
+    border-radius: 20px; overflow: hidden;
+    background: #080a0e;
+  }
+  .razr-open .screen iframe {
+    width: 360px; height: 780px;
+    border: none; display: block;
+    transform: scale(0.653);
+    transform-origin: top left;
+    pointer-events: auto;
+  }
+  .razr-open .home-bar {
+    width: 70px; height: 4px; border-radius: 2px;
+    background: rgba(255,255,255,0.1);
+    margin: 8px auto 0;
+  }
+
+  /* ── RAZR FOLDED FRAME ── */
+  .razr-folded {
+    width: 200px;
+    background: #18181a;
+    border-radius: 24px 24px 8px 8px;
+    border: 1.5px solid #2c2c2e;
+    box-shadow:
+      0 0 0 1px #0a0a0c,
+      inset 0 0 0 1px #303032,
+      0 20px 50px rgba(0,0,0,0.9);
+    position: relative;
+    padding: 10px;
+  }
+  .razr-folded .cover-screen {
+    width: 100%; height: 120px;
+    border-radius: 16px 16px 4px 4px;
+    overflow: hidden;
+    background: #080a0e;
+    position: relative;
+  }
+  .razr-folded .cover-screen iframe {
+    /* Folded outer screen: ~390px wide, 162px tall viewport */
+    width: 390px; height: 162px;
+    border: none; display: block;
+    transform: scale(0.462);
+    transform-origin: top left;
+    pointer-events: auto;
+  }
+  .razr-folded .hinge {
+    height: 14px;
+    background: linear-gradient(180deg, #111113 0%, #1a1a1c 50%, #111113 100%);
+    border-top: 1px solid #2a2a2c;
+    border-bottom: 1px solid #2a2a2c;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .razr-folded .hinge::after {
+    content: ''; width: 40px; height: 3px;
+    border-radius: 2px; background: #222224;
+  }
+  .razr-folded .body-bottom {
+    height: 14px;
+    background: #18181a;
+    border-radius: 0 0 6px 6px;
+  }
+  .razr-folded .punch-hole {
+    position: absolute; top: 10px; left: 50%;
+    transform: translateX(-50%);
+    width: 9px; height: 9px;
+    background: #000; border-radius: 50%; z-index: 10;
+  }
+
+  .note {
+    font-size: 10px; color: #2a3040; text-align: center;
+    line-height: 1.7; max-width: 200px;
+  }
+  .note span { color: #22d3ee; }
+</style>
+</head>
+<body>
+<h1>Flux Memory Dashboard — Mobile Layouts</h1>
+<div class="devices-row">
+
+  <!-- iPhone Air -->
+  <div class="device">
+    <div class="device-label">iPhone Air</div>
+    <div class="device-sub">390 × 844</div>
+    <div class="iphone-air">
+      <div class="dynamic-island"></div>
+      <div class="screen">
+        <iframe src="/" scrolling="no"></iframe>
+      </div>
+      <div class="home-bar"></div>
+    </div>
+    <div class="note">
+      Single finger: drag node<br/>
+      Two fingers: pan + pinch zoom<br/>
+      Tap node → <span>inspector bubble glows</span><br/>
+      Tap bubble → sheet slides up
+    </div>
+  </div>
+
+  <!-- Motorola Razr Unfolded -->
+  <div class="device">
+    <div class="device-label">Motorola Razr+</div>
+    <div class="device-sub">360 × 780 · Unfolded</div>
+    <div class="razr-open">
+      <div class="punch-hole"></div>
+      <div class="hinge-seam"></div>
+      <div class="screen">
+        <iframe src="/" scrolling="no"></iframe>
+      </div>
+      <div class="home-bar"></div>
+    </div>
+    <div class="note">
+      Full screen graph<br/>
+      Bubble bar at bottom<br/>
+      Hinge seam is cosmetic only
+    </div>
+  </div>
+
+  <!-- Motorola Razr Folded -->
+  <div class="device">
+    <div class="device-label">Motorola Razr+</div>
+    <div class="device-sub">390 × 162 · Folded outer screen</div>
+    <div class="razr-folded">
+      <div class="punch-hole"></div>
+      <div class="cover-screen">
+        <iframe
+          src="/"
+          scrolling="no"
+          style="height:162px"
+        ></iframe>
+      </div>
+      <div class="hinge"></div>
+      <div class="body-bottom"></div>
+    </div>
+    <div class="note">
+      Ultra-compact mode<br/>
+      Status + graph only<br/>
+      <span>No bubbles, no sheets</span><br/>
+      Quick glance view
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/design/mobile-preview/Mobile Preview.html
+++ b/design/mobile-preview/Mobile Preview.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<title>Mobile Preview — Flux Dashboard</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: #060810;
+    min-height: 100vh;
+    font-family: system-ui, sans-serif;
+    padding: 32px 24px 48px;
+    overflow-x: auto;
+  }
+
+  h1 {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.8px;
+    color: #3a4255; text-align: center; margin-bottom: 32px;
+  }
+
+  .devices-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 40px;
+    flex-wrap: wrap;
+  }
+
+  .device { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .device-label { font-size: 10px; color: #3a4255; text-transform: uppercase; letter-spacing: 0.6px; }
+  .device-sub { font-size: 10px; color: #22253a; }
+
+  /* ── IPHONE AIR FRAME ── */
+  .iphone-air {
+    width: 280px;
+    background: #1c1c1e;
+    border-radius: 50px;
+    border: 1.5px solid #2c2c2e;
+    box-shadow:
+      0 0 0 1px #0a0a0c,
+      inset 0 0 0 1px #3a3a3e,
+      0 40px 80px rgba(0,0,0,0.9),
+      0 0 40px rgba(34,211,238,0.04);
+    position: relative;
+    padding: 14px;
+  }
+  .iphone-air .dynamic-island {
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    width: 90px; height: 30px;
+    background: #000; border-radius: 20px; z-index: 10;
+  }
+  .iphone-air .screen {
+    width: 100%; height: 580px;
+    border-radius: 38px; overflow: hidden;
+    background: #080a0e;
+    position: relative;
+  }
+  .iphone-air .screen iframe {
+    width: 390px; height: 844px;
+    border: none; display: block;
+    transform: scale(0.642);
+    transform-origin: top left;
+    pointer-events: auto;
+  }
+  .iphone-air .home-bar {
+    width: 80px; height: 4px; border-radius: 2px;
+    background: rgba(255,255,255,0.12);
+    margin: 10px auto 0;
+  }
+  /* Side buttons */
+  .iphone-air::before {
+    content: '';
+    position: absolute; right: -3px; top: 120px;
+    width: 3px; height: 60px;
+    background: #2a2a2c; border-radius: 0 3px 3px 0;
+  }
+  .iphone-air::after {
+    content: '';
+    position: absolute; left: -3px; top: 100px;
+    width: 3px; height: 100px;
+    background: #2a2a2c; border-radius: 3px 0 0 3px;
+    box-shadow: 0 50px 0 #2a2a2c, 0 -50px 0 #2a2a2c;
+  }
+
+  /* ── RAZR UNFOLDED FRAME ── */
+  .razr-open {
+    width: 258px;
+    background: #18181a;
+    border-radius: 30px;
+    border: 1.5px solid #2c2c2e;
+    box-shadow:
+      0 0 0 1px #0a0a0c,
+      inset 0 0 0 1px #303032,
+      0 40px 80px rgba(0,0,0,0.9);
+    position: relative;
+    padding: 12px;
+    /* Hinge seam */
+  }
+  .razr-open .hinge-seam {
+    position: absolute; left: 12px; right: 12px;
+    top: 50%; transform: translateY(-50%);
+    height: 6px;
+    background: #0f0f11;
+    border-top: 1px solid #222224;
+    border-bottom: 1px solid #222224;
+    z-index: 20;
+    pointer-events: none;
+  }
+  .razr-open .punch-hole {
+    position: absolute; top: 18px; left: 50%;
+    transform: translateX(-50%);
+    width: 10px; height: 10px;
+    background: #000; border-radius: 50%; z-index: 10;
+  }
+  .razr-open .screen {
+    width: 100%; height: 540px;
+    border-radius: 20px; overflow: hidden;
+    background: #080a0e;
+  }
+  .razr-open .screen iframe {
+    width: 360px; height: 780px;
+    border: none; display: block;
+    transform: scale(0.653);
+    transform-origin: top left;
+    pointer-events: auto;
+  }
+  .razr-open .home-bar {
+    width: 70px; height: 4px; border-radius: 2px;
+    background: rgba(255,255,255,0.1);
+    margin: 8px auto 0;
+  }
+
+  /* ── RAZR FOLDED FRAME ── */
+  .razr-folded {
+    width: 200px;
+    background: #18181a;
+    border-radius: 24px 24px 8px 8px;
+    border: 1.5px solid #2c2c2e;
+    box-shadow:
+      0 0 0 1px #0a0a0c,
+      inset 0 0 0 1px #303032,
+      0 20px 50px rgba(0,0,0,0.9);
+    position: relative;
+    padding: 10px;
+  }
+  .razr-folded .cover-screen {
+    width: 100%; height: 120px;
+    border-radius: 16px 16px 4px 4px;
+    overflow: hidden;
+    background: #080a0e;
+    position: relative;
+  }
+  .razr-folded .cover-screen iframe {
+    /* Folded outer screen: ~390px wide, 162px tall viewport */
+    width: 390px; height: 162px;
+    border: none; display: block;
+    transform: scale(0.462);
+    transform-origin: top left;
+    pointer-events: auto;
+  }
+  .razr-folded .hinge {
+    height: 14px;
+    background: linear-gradient(180deg, #111113 0%, #1a1a1c 50%, #111113 100%);
+    border-top: 1px solid #2a2a2c;
+    border-bottom: 1px solid #2a2a2c;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .razr-folded .hinge::after {
+    content: ''; width: 40px; height: 3px;
+    border-radius: 2px; background: #222224;
+  }
+  .razr-folded .body-bottom {
+    height: 14px;
+    background: #18181a;
+    border-radius: 0 0 6px 6px;
+  }
+  .razr-folded .punch-hole {
+    position: absolute; top: 10px; left: 50%;
+    transform: translateX(-50%);
+    width: 9px; height: 9px;
+    background: #000; border-radius: 50%; z-index: 10;
+  }
+
+  .note {
+    font-size: 10px; color: #2a3040; text-align: center;
+    line-height: 1.7; max-width: 200px;
+  }
+  .note span { color: #22d3ee; }
+</style>
+</head>
+<body>
+<h1>Flux Memory Dashboard — Mobile Layouts</h1>
+<div class="devices-row">
+
+  <!-- iPhone Air -->
+  <div class="device">
+    <div class="device-label">iPhone Air</div>
+    <div class="device-sub">390 × 844</div>
+    <div class="iphone-air">
+      <div class="dynamic-island"></div>
+      <div class="screen">
+        <iframe src="Flux Dashboard.html" scrolling="no"></iframe>
+      </div>
+      <div class="home-bar"></div>
+    </div>
+    <div class="note">
+      Single finger: drag node<br/>
+      Two fingers: pan + pinch zoom<br/>
+      Tap node → <span>inspector bubble glows</span><br/>
+      Tap bubble → sheet slides up
+    </div>
+  </div>
+
+  <!-- Motorola Razr Unfolded -->
+  <div class="device">
+    <div class="device-label">Motorola Razr+</div>
+    <div class="device-sub">360 × 780 · Unfolded</div>
+    <div class="razr-open">
+      <div class="punch-hole"></div>
+      <div class="hinge-seam"></div>
+      <div class="screen">
+        <iframe src="Flux Dashboard.html" scrolling="no"></iframe>
+      </div>
+      <div class="home-bar"></div>
+    </div>
+    <div class="note">
+      Full screen graph<br/>
+      Bubble bar at bottom<br/>
+      Hinge seam is cosmetic only
+    </div>
+  </div>
+
+  <!-- Motorola Razr Folded -->
+  <div class="device">
+    <div class="device-label">Motorola Razr+</div>
+    <div class="device-sub">390 × 162 · Folded outer screen</div>
+    <div class="razr-folded">
+      <div class="punch-hole"></div>
+      <div class="cover-screen">
+        <iframe
+          src="Flux Dashboard.html"
+          scrolling="no"
+          style="height:162px"
+        ></iframe>
+      </div>
+      <div class="hinge"></div>
+      <div class="body-bottom"></div>
+    </div>
+    <div class="note">
+      Ultra-compact mode<br/>
+      Status + graph only<br/>
+      <span>No bubbles, no sheets</span><br/>
+      Quick glance view
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/design/mobile-preview/README.md
+++ b/design/mobile-preview/README.md
@@ -1,0 +1,55 @@
+# Flux Mobile Dashboard Design Pack
+
+This folder contains the mobile dashboard design files that can be reused on another Flux system.
+
+## Files
+
+- `Mobile Preview.html`
+  - Static mobile preview.
+  - Depends on `Flux Dashboard.html` in the same folder.
+  - Good for design review or handing to another UI assistant.
+
+- `Flux Dashboard.html`
+  - Standalone dashboard mock/design used by the preview iframe.
+  - Includes the visual language, graph panel, inspector, health panels, and fallback mock data.
+
+- `Mobile Preview - live.html`
+  - Same device-frame preview, but the iframe source is `/`.
+  - Use this when embedding into a running Flux dashboard server route such as `/mobile-preview`.
+
+- `DESIGN_HANDOFF_PROMPT.md`
+  - Copy-paste prompt/spec for another AI or designer.
+  - Contains the exact mobile layout intent, device frames, interaction rules, and implementation constraints.
+
+## Mobile Layout Targets
+
+- iPhone Air: `390 x 844`
+- Motorola Razr+ unfolded: `360 x 780`
+- Motorola Razr+ folded outer screen: `390 x 162`
+
+## Key Interaction Pattern
+
+- Full-screen graph first.
+- Bottom bubble bar for inspector, warnings, health, and refresh.
+- Tap node to select/highlight.
+- Tap inspector bubble to open the mobile sheet.
+- Two-finger pan/pinch for graph navigation.
+
+## Important
+
+If another AI is recreating this, give it `DESIGN_HANDOFF_PROMPT.md` plus the two HTML files. The layout depends on exact viewport targets, iframe scaling, full-screen graph-first behavior, and the bottom mobile bubble bar. A generic responsive dashboard will not match this design.
+
+## Current Flux Integration Location
+
+The live implementation is embedded in:
+
+- `src/flux/dashboard.py`
+
+Relevant sections:
+
+- `_DASHBOARD_HTML`: main dashboard HTML/CSS/JS.
+- `_MOBILE_PREVIEW_HTML`: mobile preview route.
+- `/api/graph`: graph data.
+- `/api/health`: health data.
+- `/api/events`: recent activity.
+- `/api/trace`: trace animation data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flux-memory"
-version = "0.6.0"
+version = "0.6.1"
 description = "Self-organizing retrieval fabric for AI memory"
 requires-python = ">=3.10"
 authors = [{ name = "Harsh" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
@@ -32,6 +33,9 @@ dependencies = [
     "click>=8.0",
     "argon2-cffi>=21.0",
     "pyotp>=2.8",
+    "qrcode>=7.0",
+    "mcp>=1.0",
+    "rich>=13.0",
 ]
 
 [project.optional-dependencies]
@@ -49,9 +53,9 @@ qr = [
 flux = "flux.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/harsh5i/v0.5-flux-memory"
-Repository = "https://github.com/harsh5i/v0.5-flux-memory"
-Documentation = "https://github.com/harsh5i/v0.5-flux-memory/blob/master/docs/flux-memory-docs.md"
+Homepage = "https://github.com/harsh5i/flux-memory"
+Repository = "https://github.com/harsh5i/flux-memory"
+Documentation = "https://github.com/harsh5i/flux-memory/blob/master/docs/flux-memory-docs.md"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/flux/__main__.py
+++ b/src/flux/__main__.py
@@ -1,0 +1,6 @@
+"""Module entry point for `python -m flux`."""
+
+from .cli import main
+
+
+main()

--- a/src/flux/admin_auth.py
+++ b/src/flux/admin_auth.py
@@ -101,6 +101,25 @@ class AdminAuth:
         self._save()
         return totp_uri
 
+    def verify_totp_code(self, code: str) -> bool:
+        """Return True when a setup/login TOTP code matches the stored secret."""
+        if not self._state.get("totp_enabled"):
+            return False
+        try:
+            import pyotp
+        except ImportError:
+            return False
+        secret = self._state.get("totp_secret")
+        if not secret:
+            return False
+        return bool(pyotp.TOTP(secret).verify(code, valid_window=1))
+
+    def disable_totp(self) -> None:
+        """Disable TOTP for the instance while preserving the admin password."""
+        self._state["totp_enabled"] = False
+        self._state.pop("totp_secret", None)
+        self._save()
+
     def change_password(self, new_password: str) -> None:
         if len(new_password) < 8:
             raise ValueError("Password must be at least 8 characters.")
@@ -178,20 +197,22 @@ class AdminAuth:
         except ImportError:
             return None
 
-    def show_qr(self, label: str = "flux-admin") -> None:
+    def show_qr(self, label: str = "flux-admin") -> bool:
         uri = self.totp_uri(label)
         if not uri:
             print("TOTP not enabled.")
-            return
+            return False
         try:
             import qrcode
             qr = qrcode.QRCode()
             qr.add_data(uri)
             qr.make(fit=True)
             qr.print_ascii(invert=True)
+            return True
         except ImportError:
             print(f"TOTP URI (scan with authenticator app):\n{uri}")
             print("(install 'qrcode' for inline QR: pip install qrcode)")
+            return False
 
     # ---------------------------------------------------------------- internals
 

--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -23,6 +23,9 @@ Subcommands:
   flux warmup [--name NAME]
               Load the local embedding model once to populate its cache.
 
+  flux rebuild-graph [--name NAME]
+              Backfill embeddings and conduits for existing bare grains.
+
   flux admin  [--name NAME]
               Interactive admin menu (password + TOTP gated).
 
@@ -38,6 +41,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import sqlite3
 import subprocess
 import sys
 import textwrap
@@ -156,6 +160,25 @@ def _warmup_embedding_model(cfg) -> tuple[str, int, float]:
     vector = emb.embed("flux warmup")
     elapsed = time.perf_counter() - start
     return cfg.EMBEDDING_MODEL_NAME, len(vector), elapsed
+
+
+def _rebuild_instance_graph(name: str, limit: int | None = None) -> dict:
+    from flux.config import Config
+    from flux.embedding import SentenceTransformerBackend
+    from flux.extraction import rebuild_missing_graph
+    from flux.llm import OllamaBackend
+    from flux.storage import FluxStore
+
+    cfg_path = _config_file(name)
+    cfg = Config.from_yaml(cfg_path) if cfg_path.exists() else Config()
+    with FluxStore(_db_file(name)) as store:
+        return rebuild_missing_graph(
+            store,
+            OllamaBackend(cfg),
+            SentenceTransformerBackend(cfg.EMBEDDING_MODEL_NAME),
+            cfg,
+            limit=limit,
+        )
 
 
 def _configured_pids_from_ports(ports: list[int]) -> set[int]:
@@ -488,6 +511,37 @@ try:
         model_name, dimensions, elapsed = _warmup_embedding_model(cfg)
         click.secho(
             f"Embedding model warmed: {model_name} ({dimensions} dims, {elapsed:.2f}s)",
+            fg="green",
+        )
+
+    @cli.command("rebuild-graph")
+    @click.option("--name", default=_DEFAULT_NAME, show_default=True)
+    @click.option("--limit", type=int, default=None,
+                  help="Maximum number of grains to rebuild.")
+    def rebuild_graph(name: str, limit: int | None) -> None:
+        """Backfill embeddings and conduits for existing bare grains."""
+        cfg_path = _config_file(name)
+        if not cfg_path.exists():
+            click.echo(f"Instance '{name}' not initialized. Run: flux init --name {name}")
+            sys.exit(1)
+
+        click.echo(f"Rebuilding graph artifacts for instance '{name}'...")
+        try:
+            stats = _rebuild_instance_graph(name, limit)
+        except sqlite3.OperationalError as exc:
+            if "locked" in str(exc).lower():
+                click.secho(
+                    "Database is locked. Stop the running Flux service, then rerun "
+                    f"`flux rebuild-graph --name {name}`.",
+                    fg="red",
+                )
+                sys.exit(1)
+            raise
+        click.secho(
+            "Graph rebuild complete: "
+            f"{stats['grains_rebuilt']} rebuilt, "
+            f"{stats['embeddings_created']} embeddings, "
+            f"{stats['conduits_created']} conduits",
             fg="green",
         )
 

--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -38,9 +38,11 @@ PID file lives at:        ~/.flux/<name>/flux.pid
 """
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 import os
 import signal
+import socket
 import sqlite3
 import subprocess
 import sys
@@ -104,6 +106,22 @@ def _wait_for_url(url: str, timeout: float = 10.0) -> bool:
             return True
         time.sleep(0.25)
     return False
+
+
+def _dashboard_probe_host(host: str) -> str:
+    return "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+
+
+def _lan_dashboard_urls(port: int) -> list[str]:
+    hosts: set[str] = set()
+    try:
+        hostname = socket.gethostname()
+        for addr in socket.gethostbyname_ex(hostname)[2]:
+            if addr and not addr.startswith("127."):
+                hosts.add(addr)
+    except OSError:
+        pass
+    return [f"http://{host}:{port}" for host in sorted(hosts)]
 
 
 def _mcp_command_parts(name: str) -> tuple[str, list[str]]:
@@ -335,7 +353,14 @@ try:
     @click.option("--name", default=_DEFAULT_NAME, show_default=True)
     @click.option("--foreground", is_flag=True, default=False,
                   help="Run in foreground (blocking). Default: background.")
-    def start(name: str, foreground: bool) -> None:
+    @click.option(
+        "--broadcast",
+        "broadcast_dashboard",
+        is_flag=True,
+        default=False,
+        help="Expose the dashboard on the local network by binding it to 0.0.0.0.",
+    )
+    def start(name: str, foreground: bool, broadcast_dashboard: bool) -> None:
         """Launch REST API and dashboard."""
         idir = _instance_dir(name)
         if not _config_file(name).exists():
@@ -357,6 +382,8 @@ try:
 
         from flux.config import Config
         cfg = Config.from_yaml(cfg_path) if cfg_path.exists() else Config()
+        if broadcast_dashboard:
+            cfg = replace(cfg, DASHBOARD_HOST="0.0.0.0")
 
         click.echo(f"Starting Flux Memory instance '{name}'...")
 
@@ -368,7 +395,7 @@ try:
             log_handle = log_path.open("ab")
             proc = subprocess.Popen(
                 [sys.executable, "-m", "flux.cli", "start",
-                 "--name", name, "--foreground"],
+                 "--name", name, "--foreground"] + (["--broadcast"] if broadcast_dashboard else []),
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
@@ -377,8 +404,9 @@ try:
             pid_path.write_text(str(proc.pid), encoding="utf-8")
 
             rest_url = f"http://{cfg.REST_HOST}:{cfg.REST_PORT}/health"
-            dashboard_url = f"http://{cfg.DASHBOARD_HOST}:{cfg.DASHBOARD_PORT}/"
-            dashboard_api = f"http://{cfg.DASHBOARD_HOST}:{cfg.DASHBOARD_PORT}/api/health"
+            dashboard_probe = _dashboard_probe_host(cfg.DASHBOARD_HOST)
+            dashboard_url = f"http://{dashboard_probe}:{cfg.DASHBOARD_PORT}/"
+            dashboard_api = f"http://{dashboard_probe}:{cfg.DASHBOARD_PORT}/api/health"
 
             rest_ok = _wait_for_url(rest_url)
             dash_ok = _wait_for_url(dashboard_url) and _wait_for_url(dashboard_api)
@@ -400,6 +428,15 @@ try:
 
             click.echo(f"  REST API:  http://localhost:{cfg.REST_PORT}/health")
             click.echo(f"  Dashboard: http://localhost:{cfg.DASHBOARD_PORT}")
+            if broadcast_dashboard:
+                lan_urls = _lan_dashboard_urls(cfg.DASHBOARD_PORT)
+                if lan_urls:
+                    click.echo("  Mobile/LAN dashboard:")
+                    for url in lan_urls:
+                        click.echo(f"       {url}")
+                    click.echo("       Preview: add /mobile-preview")
+                else:
+                    click.echo("  Mobile/LAN dashboard: bound to 0.0.0.0; use this machine's LAN IP.")
             click.echo("  MCP: stdio/client-launched; not started by `flux start`")
             click.echo(f"       Add client config from: {_mcp_client_config_hint(name)}")
             click.echo(f"  Stop with: flux stop --name {name}")

--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -140,6 +140,10 @@ def _write_mcp_client_configs(name: str) -> dict[str, Path]:
     }
 
 
+def _mcp_client_config_hint(name: str) -> str:
+    return str(_integrations_dir(name) / "codex.toml")
+
+
 def _configured_pids_from_ports(ports: list[int]) -> set[int]:
     if os.name != "nt":
         return set()
@@ -284,7 +288,7 @@ try:
 
         click.secho(f"\nOK Instance '{name}' initialized.", fg="green", bold=True)
         click.echo(f"  Run `flux start --name {name}` to launch REST and dashboard.")
-        click.echo(f"  Run `flux mcp --name {name}` from your MCP client config.")
+        click.echo(f"  MCP is stdio/client-launched; add the generated snippet to your MCP client.")
         click.echo(f"  MCP client snippets written to: {_integrations_dir(name)}")
         click.echo(f"  Codex snippet: {snippets['codex']}")
 
@@ -359,7 +363,8 @@ try:
 
             click.echo(f"  REST API:  http://localhost:{cfg.REST_PORT}/health")
             click.echo(f"  Dashboard: http://localhost:{cfg.DASHBOARD_PORT}")
-            click.echo(f"  MCP: configure your client with `flux mcp --name {name}`")
+            click.echo("  MCP: stdio/client-launched; not started by `flux start`")
+            click.echo(f"       Add client config from: {_mcp_client_config_hint(name)}")
             click.echo(f"  Stop with: flux stop --name {name}")
 
     # ---------------------------------------------------------------- stop
@@ -438,7 +443,8 @@ try:
             click.echo(f"  Mode:      {cfg.OPERATING_MODE}")
             click.echo(f"  REST:      {'up' if rest_ok else 'down'}  http://localhost:{cfg.REST_PORT}/health")
             click.echo(f"  Dashboard: {'up' if dashboard_ok else 'down'}  http://localhost:{cfg.DASHBOARD_PORT}")
-            click.echo(f"  MCP:       configure client with `flux mcp --name {name}`")
+            click.echo("  MCP:       stdio/client-launched; not a background network server")
+            click.echo(f"             Add client config from: {_mcp_client_config_hint(name)}")
 
             if rest_ok:
                 try:

--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -43,7 +43,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-_VERSION = "0.6.0"
+_VERSION = "0.6.1"
 _DEFAULT_NAME = "flux-memory"
 _FLUX_HOME = Path.home() / ".flux"
 
@@ -302,7 +302,7 @@ try:
             sys.exit(1)
 
         pid_path = _pid_file(name)
-        if pid_path.exists():
+        if not foreground and pid_path.exists():
             pid = int(pid_path.read_text().strip())
             try:
                 os.kill(pid, 0)

--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -20,6 +20,9 @@ Subcommands:
   flux status [--name NAME]
               Show running service status and basic health.
 
+  flux warmup [--name NAME]
+              Load the local embedding model once to populate its cache.
+
   flux admin  [--name NAME]
               Interactive admin menu (password + TOTP gated).
 
@@ -142,6 +145,17 @@ def _write_mcp_client_configs(name: str) -> dict[str, Path]:
 
 def _mcp_client_config_hint(name: str) -> str:
     return str(_integrations_dir(name) / "codex.toml")
+
+
+def _warmup_embedding_model(cfg) -> tuple[str, int, float]:
+    """Load the configured embedding model and run one tiny embed."""
+    from flux.embedding import SentenceTransformerBackend
+
+    start = time.perf_counter()
+    emb = SentenceTransformerBackend(cfg.EMBEDDING_MODEL_NAME)
+    vector = emb.embed("flux warmup")
+    elapsed = time.perf_counter() - start
+    return cfg.EMBEDDING_MODEL_NAME, len(vector), elapsed
 
 
 def _configured_pids_from_ports(ports: list[int]) -> set[int]:
@@ -455,6 +469,27 @@ try:
                     click.echo("  Health:    (could not parse REST health)")
         else:
             click.echo(f"Instance '{name}': STOPPED")
+
+    # ---------------------------------------------------------------- warmup
+
+    @cli.command("warmup")
+    @click.option("--name", default=_DEFAULT_NAME, show_default=True)
+    def warmup(name: str) -> None:
+        """Load the configured embedding model once to populate its cache."""
+        cfg_path = _config_file(name)
+        if not cfg_path.exists():
+            click.echo(f"Instance '{name}' not initialized. Run: flux init --name {name}")
+            sys.exit(1)
+
+        from flux.config import Config
+
+        cfg = Config.from_yaml(cfg_path)
+        click.echo(f"Warming embedding model for instance '{name}'...")
+        model_name, dimensions, elapsed = _warmup_embedding_model(cfg)
+        click.secho(
+            f"Embedding model warmed: {model_name} ({dimensions} dims, {elapsed:.2f}s)",
+            fg="green",
+        )
 
     # ---------------------------------------------------------------- mcp
 

--- a/src/flux/cli.py
+++ b/src/flux/cli.py
@@ -8,7 +8,11 @@ Subcommands:
               optionally sets up TOTP 2FA.
 
   flux start  [--name NAME]
-              Launch MCP server, REST API, and dashboard as background services.
+              Launch REST API and dashboard as background services.
+
+  flux mcp    [--name NAME]
+              Run the stdio MCP server for one instance. MCP clients launch
+              this command directly.
 
   flux stop   [--name NAME]
               Gracefully stop all services for the named instance.
@@ -34,6 +38,9 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 _VERSION = "0.6.0"
@@ -59,6 +66,108 @@ def _db_file(name: str, db: str | None = None) -> Path:
     return _instance_dir(name) / "flux.db"
 
 
+def _log_file(name: str) -> Path:
+    return _instance_dir(name) / "flux.log"
+
+
+def _integrations_dir(name: str) -> Path:
+    return _instance_dir(name) / "integrations"
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _url_ok(url: str, timeout: float = 2.0) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return 200 <= resp.status < 400
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def _wait_for_url(url: str, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _url_ok(url, timeout=1.0):
+            return True
+        time.sleep(0.25)
+    return False
+
+
+def _mcp_command_parts(name: str) -> tuple[str, list[str]]:
+    return sys.executable, ["-m", "flux.cli", "mcp", "--name", name]
+
+
+def _toml_literal(value: str) -> str:
+    return json.dumps(value)
+
+
+def _write_mcp_client_configs(name: str) -> dict[str, Path]:
+    command, args = _mcp_command_parts(name)
+    server_key = f"flux-{name}"
+    out = _integrations_dir(name)
+    out.mkdir(parents=True, exist_ok=True)
+
+    codex = (
+        f"[mcp_servers.\"{server_key}\"]\n"
+        f"command = {_toml_literal(command)}\n"
+        f"args = {json.dumps(args)}\n"
+    )
+    claude = {
+        "mcpServers": {
+            server_key: {
+                "command": command,
+                "args": args,
+            }
+        }
+    }
+
+    codex_path = out / "codex.toml"
+    claude_path = out / "claude_desktop.json"
+    cursor_path = out / "cursor.json"
+    codex_path.write_text(codex, encoding="utf-8")
+    claude_path.write_text(json.dumps(claude, indent=2), encoding="utf-8")
+    cursor_path.write_text(json.dumps(claude, indent=2), encoding="utf-8")
+    return {
+        "codex": codex_path,
+        "claude": claude_path,
+        "cursor": cursor_path,
+    }
+
+
+def _configured_pids_from_ports(ports: list[int]) -> set[int]:
+    if os.name != "nt":
+        return set()
+    try:
+        output = subprocess.check_output(
+            ["netstat", "-ano"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return set()
+    pids: set[int] = set()
+    wanted = {f":{p}" for p in ports}
+    for line in output.splitlines():
+        if "LISTENING" not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+        local = parts[1]
+        if any(marker in local for marker in wanted):
+            try:
+                pids.add(int(parts[-1]))
+            except ValueError:
+                pass
+    return pids
+
+
 # ---------------------------------------------------------------- main entry
 
 def main() -> None:
@@ -66,7 +175,7 @@ def main() -> None:
     try:
         import click
     except ImportError:
-        print("ERROR: 'click' package required. pip install flux-memory[cli]")
+        print("ERROR: 'click' package required. pip install flux-memory")
         sys.exit(1)
     cli()
 
@@ -87,7 +196,7 @@ try:
     @click.group()
     @click.version_option(version=_VERSION, prog_name="flux")
     def cli():
-        """Flux Memory — self-organizing retrieval fabric for AI memory."""
+        """Flux Memory - self-organizing retrieval fabric for AI memory."""
 
     # ---------------------------------------------------------------- init
 
@@ -104,14 +213,14 @@ try:
         db_path = _db_file(name, db)
 
         click.echo(f"\n{'='*60}")
-        click.echo(f"  Flux Memory — Instance Setup: {name}")
+        click.secho(f"  Flux Memory - Instance Setup: {name}", fg="cyan", bold=True)
         click.echo(f"{'='*60}\n")
 
         # Operating mode.
         if mode is None:
             click.echo("Choose operating mode:")
-            click.echo("  1) caller_extracts  — AI does feature/grain extraction (no local LLM needed)")
-            click.echo("  2) flux_extracts    — Flux runs its own LLM via Ollama (requires Ollama)\n")
+            click.echo("  1) caller_extracts  - AI does feature/grain extraction (no local LLM needed)")
+            click.echo("  2) flux_extracts    - Flux runs its own LLM via Ollama (requires Ollama)\n")
             choice = click.prompt("Mode", type=click.Choice(["1", "2"]), default="2")
             mode = "caller_extracts" if choice == "1" else "flux_extracts"
 
@@ -122,7 +231,7 @@ try:
         }
         cfg_path = _config_file(name)
         import yaml
-        cfg_path.write_text(yaml.dump(config, default_flow_style=False))
+        cfg_path.write_text(yaml.dump(config, default_flow_style=False), encoding="utf-8")
 
         click.echo(f"\nConfig written to: {cfg_path}")
         click.echo(f"Database will be:  {db_path}")
@@ -154,14 +263,30 @@ try:
 
         if totp_uri:
             click.echo("\n--- TOTP Setup ---")
-            click.echo("Scan the QR code below with your authenticator app")
-            click.echo("(Google Authenticator, Authy, 1Password, etc.):\n")
-            auth.show_qr()
-            click.echo(f"\nTOTP URI (if QR display failed):\n{totp_uri}\n")
-            click.confirm("Have you scanned the QR code?", default=True)
+            shown = auth.show_qr()
+            if shown:
+                click.echo("\nScan the QR code above with your authenticator app.")
+            else:
+                click.echo("\nQR display unavailable. Use this manual TOTP URI:")
+            click.echo(f"{totp_uri}\n")
+            while True:
+                code = click.prompt("Enter the 6-digit code from your authenticator")
+                if auth.verify_totp_code(code):
+                    click.secho("TOTP verified.", fg="green")
+                    break
+                click.secho("Invalid TOTP code.", fg="red")
+                if not click.confirm("Try another code?", default=True):
+                    auth.disable_totp()
+                    click.secho("TOTP disabled for this instance.", fg="yellow")
+                    break
 
-        click.echo(f"\n✓ Instance '{name}' initialized.")
-        click.echo(f"  Run `flux start --name {name}` to launch services.")
+        snippets = _write_mcp_client_configs(name)
+
+        click.secho(f"\nOK Instance '{name}' initialized.", fg="green", bold=True)
+        click.echo(f"  Run `flux start --name {name}` to launch REST and dashboard.")
+        click.echo(f"  Run `flux mcp --name {name}` from your MCP client config.")
+        click.echo(f"  MCP client snippets written to: {_integrations_dir(name)}")
+        click.echo(f"  Codex snippet: {snippets['codex']}")
 
     # ---------------------------------------------------------------- start
 
@@ -170,7 +295,7 @@ try:
     @click.option("--foreground", is_flag=True, default=False,
                   help="Run in foreground (blocking). Default: background.")
     def start(name: str, foreground: bool) -> None:
-        """Launch MCP server, REST API, and dashboard."""
+        """Launch REST API and dashboard."""
         idir = _instance_dir(name)
         if not _config_file(name).exists():
             click.echo(f"Instance '{name}' not initialized. Run: flux init --name {name}")
@@ -197,17 +322,44 @@ try:
         if foreground:
             _run_services(name, db_path, cfg)
         else:
+            log_path = _log_file(name)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_handle = log_path.open("ab")
             proc = subprocess.Popen(
                 [sys.executable, "-m", "flux.cli", "start",
                  "--name", name, "--foreground"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
                 start_new_session=True,
             )
-            pid_path.write_text(str(proc.pid))
-            click.echo(f"  Services started (PID {proc.pid})")
-            click.echo(f"  REST API:  http://localhost:{cfg.REST_PORT}")
+            log_handle.close()
+            pid_path.write_text(str(proc.pid), encoding="utf-8")
+
+            rest_url = f"http://{cfg.REST_HOST}:{cfg.REST_PORT}/health"
+            dashboard_url = f"http://{cfg.DASHBOARD_HOST}:{cfg.DASHBOARD_PORT}/"
+            dashboard_api = f"http://{cfg.DASHBOARD_HOST}:{cfg.DASHBOARD_PORT}/api/health"
+
+            rest_ok = _wait_for_url(rest_url)
+            dash_ok = _wait_for_url(dashboard_url) and _wait_for_url(dashboard_api)
+
+            if proc.poll() is not None:
+                click.secho(f"  Services failed to stay running (PID {proc.pid}).", fg="red")
+                click.echo(f"  Log: {log_path}")
+                sys.exit(1)
+
+            if rest_ok and dash_ok:
+                click.secho(f"  Services started (PID {proc.pid})", fg="green")
+            else:
+                click.secho(f"  Services partially started (PID {proc.pid})", fg="yellow")
+                if not rest_ok:
+                    click.echo(f"  REST health not reachable: {rest_url}")
+                if not dash_ok:
+                    click.echo(f"  Dashboard not fully reachable: {dashboard_url}")
+                click.echo(f"  Log: {log_path}")
+
+            click.echo(f"  REST API:  http://localhost:{cfg.REST_PORT}/health")
             click.echo(f"  Dashboard: http://localhost:{cfg.DASHBOARD_PORT}")
+            click.echo(f"  MCP: configure your client with `flux mcp --name {name}`")
             click.echo(f"  Stop with: flux stop --name {name}")
 
     # ---------------------------------------------------------------- stop
@@ -216,18 +368,41 @@ try:
     @click.option("--name", default=_DEFAULT_NAME, show_default=True)
     def stop(name: str) -> None:
         """Stop all services for the named instance."""
+        cfg_path = _config_file(name)
+        cfg = None
+        if cfg_path.exists():
+            from flux.config import Config
+            cfg = Config.from_yaml(cfg_path)
+
         pid_path = _pid_file(name)
-        if not pid_path.exists():
-            click.echo(f"No PID file found for instance '{name}'. May not be running.")
+        pids: set[int] = set()
+        if pid_path.exists():
+            try:
+                pids.add(int(pid_path.read_text(encoding="utf-8").strip()))
+            except ValueError:
+                pid_path.unlink(missing_ok=True)
+
+        if cfg is not None:
+            pids.update(_configured_pids_from_ports([cfg.REST_PORT, cfg.DASHBOARD_PORT]))
+
+        if not pids:
+            click.echo(f"No running process found for instance '{name}'.")
             return
-        pid = int(pid_path.read_text().strip())
-        try:
-            os.kill(pid, signal.SIGTERM)
-            pid_path.unlink(missing_ok=True)
-            click.echo(f"Instance '{name}' (PID {pid}) stopped.")
-        except OSError as exc:
-            click.echo(f"Could not stop PID {pid}: {exc}")
-            pid_path.unlink(missing_ok=True)
+
+        stopped = []
+        failed = []
+        for pid in sorted(pids):
+            try:
+                os.kill(pid, signal.SIGTERM)
+                stopped.append(pid)
+            except OSError as exc:
+                failed.append((pid, exc))
+
+        pid_path.unlink(missing_ok=True)
+        if stopped:
+            click.secho(f"Stopped instance '{name}' process(es): {', '.join(map(str, stopped))}", fg="green")
+        for pid, exc in failed:
+            click.secho(f"Could not stop PID {pid}: {exc}", fg="red")
 
     # ---------------------------------------------------------------- status
 
@@ -236,39 +411,82 @@ try:
     def status(name: str) -> None:
         """Show running status and health for the named instance."""
         pid_path = _pid_file(name)
-        running = False
+        pid_running = False
+        pid = None
         if pid_path.exists():
-            pid = int(pid_path.read_text().strip())
             try:
+                pid = int(pid_path.read_text(encoding="utf-8").strip())
                 os.kill(pid, 0)
-                running = True
-                click.echo(f"Instance '{name}': RUNNING (PID {pid})")
-            except OSError:
-                click.echo(f"Instance '{name}': STOPPED (stale PID file)")
+                pid_running = True
+            except (OSError, ValueError):
                 pid_path.unlink(missing_ok=True)
-        else:
-            click.echo(f"Instance '{name}': STOPPED")
 
         cfg_path = _config_file(name)
         if cfg_path.exists():
             from flux.config import Config
             cfg = Config.from_yaml(cfg_path)
+            rest_url = f"http://{cfg.REST_HOST}:{cfg.REST_PORT}/health"
+            dashboard_url = f"http://{cfg.DASHBOARD_HOST}:{cfg.DASHBOARD_PORT}/"
+            rest_ok = _url_ok(rest_url)
+            dashboard_ok = _url_ok(dashboard_url)
+            running = pid_running or rest_ok or dashboard_ok
+            if running:
+                pid_text = f"PID {pid}" if pid_running and pid is not None else "no PID file"
+                click.echo(f"Instance '{name}': RUNNING ({pid_text})")
+            else:
+                click.echo(f"Instance '{name}': STOPPED")
             click.echo(f"  Mode:      {cfg.OPERATING_MODE}")
-            click.echo(f"  REST port: {cfg.REST_PORT}")
-            click.echo(f"  Dashboard: {cfg.DASHBOARD_PORT}")
+            click.echo(f"  REST:      {'up' if rest_ok else 'down'}  http://localhost:{cfg.REST_PORT}/health")
+            click.echo(f"  Dashboard: {'up' if dashboard_ok else 'down'}  http://localhost:{cfg.DASHBOARD_PORT}")
+            click.echo(f"  MCP:       configure client with `flux mcp --name {name}`")
 
-        if running:
-            try:
-                import urllib.request
-                from flux.config import Config
-                cfg = Config.from_yaml(cfg_path) if cfg_path.exists() else Config()
-                with urllib.request.urlopen(
-                    f"http://localhost:{cfg.REST_PORT}/health", timeout=3
-                ) as resp:
-                    h = json.loads(resp.read())
-                    click.echo(f"  Health:    {h.get('status', 'unknown')}")
-            except Exception:
-                click.echo("  Health:    (could not reach REST API)")
+            if rest_ok:
+                try:
+                    with urllib.request.urlopen(rest_url, timeout=3) as resp:
+                        h = json.loads(resp.read())
+                        click.echo(f"  Health:    {h.get('status', 'unknown')}")
+                except Exception:
+                    click.echo("  Health:    (could not parse REST health)")
+        else:
+            click.echo(f"Instance '{name}': STOPPED")
+
+    # ---------------------------------------------------------------- mcp
+
+    @cli.command("mcp")
+    @click.option("--name", default=_DEFAULT_NAME, show_default=True)
+    def mcp_server(name: str) -> None:
+        """Run the stdio MCP server for an initialized instance."""
+        cfg_path = _config_file(name)
+        if not cfg_path.exists():
+            click.echo(f"Instance '{name}' not initialized. Run: flux init --name {name}", err=True)
+            sys.exit(1)
+
+        from flux.config import Config
+        from flux.storage import FluxStore
+        from flux.service import FluxService
+        from flux.mcp_server import run_stdio
+
+        cfg = Config.from_yaml(cfg_path)
+        store = FluxStore(_db_file(name))
+        service = FluxService(store, cfg=cfg)
+        service.start()
+        try:
+            run_stdio(store, service._llm, service._emb, cfg, service=service)
+        finally:
+            service.stop()
+            store.close()
+
+    @cli.command("mcp-config")
+    @click.option("--name", default=_DEFAULT_NAME, show_default=True)
+    def mcp_config(name: str) -> None:
+        """Write MCP client config snippets for Codex, Claude, and Cursor."""
+        if not _config_file(name).exists():
+            click.echo(f"Instance '{name}' not initialized. Run: flux init --name {name}")
+            sys.exit(1)
+        paths = _write_mcp_client_configs(name)
+        click.secho(f"MCP client snippets written to {_integrations_dir(name)}", fg="green")
+        for label, path in paths.items():
+            click.echo(f"  {label}: {path}")
 
     # ---------------------------------------------------------------- admin
 
@@ -401,6 +619,7 @@ Admin Menu:
     def _run_services(name: str, db_path: Path, cfg) -> None:
         """Start all services in the foreground (blocking)."""
         import threading
+        import traceback
         from flux.storage import FluxStore
         from flux.service import FluxService
 
@@ -418,32 +637,38 @@ Admin Menu:
             app = build_app(service, cfg)
 
             def _rest():
-                uvicorn.run(app, host="0.0.0.0", port=cfg.REST_PORT, log_level="warning")
+                uvicorn.run(app, host=cfg.REST_HOST, port=cfg.REST_PORT, log_level="warning")
 
             t = threading.Thread(target=_rest, name="flux-rest", daemon=True)
             t.start()
             threads.append(t)
         except ImportError:
-            pass
+            print("REST API requires fastapi and uvicorn.", file=sys.stderr)
+            traceback.print_exc()
 
         # Dashboard thread.
         try:
             from flux.dashboard import run_dashboard
             t = threading.Thread(
                 target=run_dashboard,
-                kwargs={"store": store, "cfg": cfg, "port": cfg.DASHBOARD_PORT},
+                kwargs={
+                    "store": store,
+                    "cfg": cfg,
+                    "host": cfg.DASHBOARD_HOST,
+                    "port": cfg.DASHBOARD_PORT,
+                },
                 name="flux-dashboard",
                 daemon=True,
             )
             t.start()
             threads.append(t)
         except Exception:
-            pass
+            print("Dashboard failed to start.", file=sys.stderr)
+            traceback.print_exc()
 
-        # MCP server (blocking, must be last).
         try:
-            from flux.mcp_server import run_stdio
-            run_stdio(store, service._llm, service._emb, cfg)
+            while True:
+                time.sleep(1)
         except KeyboardInterrupt:
             pass
         finally:
@@ -453,7 +678,7 @@ Admin Menu:
 except ImportError:
     # click not installed — provide a minimal shim so `python -m flux.cli` gives useful message.
     def main() -> None:  # type: ignore[misc]
-        print("Flux Memory CLI requires 'click'. Install: pip install 'flux-memory[cli]'")
+        print("Flux Memory CLI requires 'click'. Install: pip install flux-memory")
         sys.exit(1)
 
     def cli() -> None:  # type: ignore[misc]

--- a/src/flux/config.py
+++ b/src/flux/config.py
@@ -112,9 +112,13 @@ class Config:
 
     # --- MCP server identity (§1A.2) ---
     MCP_SERVER_NAME: str = "flux-memory"
+    MCP_HOST: str = "127.0.0.1"
     MCP_PORT: int = 7464
+    REST_HOST: str = "127.0.0.1"
     REST_PORT: int = 7465
+    ADMIN_REST_HOST: str = "127.0.0.1"
     ADMIN_REST_PORT: int = 7463
+    DASHBOARD_HOST: str = "127.0.0.1"
     DASHBOARD_PORT: int = 7462
 
     # --- Booth architecture (§1A.7) ---

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -636,21 +636,7 @@ function nodeMatchesSearch(n) {
 
 function getVisibleNodes() {
   if (!graphData) return [];
-  const baseNodes = graphData.nodes.filter(nodePassesFilters);
-  if (!searchQuery) return baseNodes;
-
-  const baseIds = new Set(baseNodes.map(n => n.id));
-  const matchedIds = new Set(baseNodes.filter(nodeMatchesSearch).map(n => n.id));
-  const visibleIds = new Set(matchedIds);
-
-  for (const link of graphData.links || []) {
-    const sid = typeof link.source === 'object' ? link.source.id : link.source;
-    const tid = typeof link.target === 'object' ? link.target.id : link.target;
-    if (matchedIds.has(sid) && baseIds.has(tid)) visibleIds.add(tid);
-    if (matchedIds.has(tid) && baseIds.has(sid)) visibleIds.add(sid);
-  }
-
-  return baseNodes.filter(n => visibleIds.has(n.id));
+  return graphData.nodes.filter(nodePassesFilters);
 }
 
 function getVisibleLinks(nodeIds) {
@@ -671,6 +657,21 @@ let transform = d3.zoomIdentity;
 let hoveredNode = null, hoveredEdge = null;
 let dashOffset = 0;
 let nudgeTimer = null;
+let searchMatchIds = new Set();
+
+function updateSearchFocus() {
+  searchMatchIds = new Set();
+  for (const node of canvasNodes) {
+    node._searchMatch = Boolean(searchQuery && nodeMatchesSearch(node));
+    if (node._searchMatch) searchMatchIds.add(node.id);
+  }
+}
+
+function edgeMatchesSearch(edge) {
+  return Boolean(searchQuery && (
+    searchMatchIds.has(edge.source?.id) || searchMatchIds.has(edge.target?.id)
+  ));
+}
 
 function renderGraph() {
   const container = document.getElementById('graph-container');
@@ -691,6 +692,7 @@ function renderGraph() {
   canvasNodes = visNodes.map(n => ({...n}));
   const nodeMap = new Map(canvasNodes.map(n => [n.id, n]));
   assignPhases(canvasNodes);
+  updateSearchFocus();
   canvasLinks = visLinks.map(l => ({
     ...l,
     source: nodeMap.get(typeof l.source==='object'?l.source.id:l.source) || (typeof l.source==='object'?l.source.id:l.source),
@@ -768,15 +770,19 @@ function draw() {
 
     const isSelected = selectedEdge === l;
     const isHovered = hoveredEdge === l;
-    const isDimmed = (selectedNode && l.source !== selectedNode && l.target !== selectedNode);
+    const isSearchMatch = edgeMatchesSearch(l);
+    const isSearchDimmed = searchQuery && !isSearchMatch;
+    const isDimmed = !isSelected && !isHovered && (
+      (selectedNode && l.source !== selectedNode && l.target !== selectedNode) || isSearchDimmed
+    );
 
     const w = Math.max(0.5, (l.effective_weight??0.3)*2.5);
-    let alpha = isDimmed ? 0.04 : (isSelected||isHovered) ? 1 : 0.55;
+    let alpha = isDimmed ? 0.05 : (isSelected||isHovered||isSearchMatch) ? 1 : 0.55;
 
     ctx.save();
     ctx.globalAlpha = alpha;
-    ctx.strokeStyle = isSelected ? '#22d3ee' : edgeColor(l);
-    ctx.lineWidth = isSelected ? w+1 : w;
+    ctx.strokeStyle = (isSelected || isSearchMatch) ? '#22d3ee' : edgeColor(l);
+    ctx.lineWidth = isSelected ? w+1 : isSearchMatch ? w+0.8 : w;
 
     // Dashed flow for core/bidirectional
     if (l.decay_class==='core' || l.direction==='bidirectional') {
@@ -796,7 +802,7 @@ function draw() {
     const r = nodeRadius(l.target)+3;
     const ax = tx - r*Math.cos(angle), ay = ty - r*Math.sin(angle);
     ctx.setLineDash([]);
-    ctx.fillStyle = isSelected ? '#22d3ee' : edgeColor(l);
+    ctx.fillStyle = (isSelected || isSearchMatch) ? '#22d3ee' : edgeColor(l);
     ctx.beginPath();
     ctx.moveTo(ax, ay);
     ctx.lineTo(ax - 8*Math.cos(angle-0.4), ay - 8*Math.sin(angle-0.4));
@@ -812,12 +818,28 @@ function draw() {
     const r = nodeRadius(n);
     const isSelected = selectedNode === n;
     const isHovered = hoveredNode === n;
-    const isDimmed = (selectedNode && selectedNode !== n && !isNeighbor(selectedNode, n));
-    const alpha = isDimmed ? 0.1 : 1;
+    const isSearchMatch = Boolean(searchQuery && n._searchMatch);
+    const isSearchDimmed = searchQuery && !isSearchMatch;
+    const isDimmed = !isSelected && !isHovered && (
+      (selectedNode && selectedNode !== n && !isNeighbor(selectedNode, n)) || isSearchDimmed
+    );
+    const alpha = isDimmed ? 0.14 : 1;
     const dormant = n.status === 'dormant';
 
     ctx.save();
     ctx.globalAlpha = alpha;
+
+    // Search focus ring
+    if (isSearchMatch) {
+      const glowR = r + 12 + Math.sin(t * 3 + n._phase) * 2;
+      const grad = ctx.createRadialGradient(n.x, n.y, r, n.x, n.y, glowR);
+      grad.addColorStop(0, 'rgba(251,191,36,0.34)');
+      grad.addColorStop(1, 'rgba(251,191,36,0)');
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, glowR, 0, Math.PI*2);
+      ctx.fillStyle = grad;
+      ctx.fill();
+    }
 
     // Glow for core grains
     if (n.decay_class === 'core' && !dormant) {
@@ -832,11 +854,11 @@ function draw() {
     }
 
     // Selection ring
-    if (isSelected || isHovered) {
+    if (isSelected || isHovered || isSearchMatch) {
       ctx.beginPath();
-      ctx.arc(n.x, n.y, r + 4, 0, Math.PI*2);
-      ctx.strokeStyle = isSelected ? '#22d3ee' : 'rgba(34,211,238,0.4)';
-      ctx.lineWidth = isSelected ? 2 : 1;
+      ctx.arc(n.x, n.y, r + (isSearchMatch ? 6 : 4), 0, Math.PI*2);
+      ctx.strokeStyle = isSelected ? '#22d3ee' : isSearchMatch ? '#fbbf24' : 'rgba(34,211,238,0.4)';
+      ctx.lineWidth = isSelected || isSearchMatch ? 2 : 1;
       ctx.stroke();
     }
 
@@ -851,7 +873,7 @@ function draw() {
     ctx.beginPath();
     ctx.arc(n.x, n.y, br, 0, Math.PI*2);
     ctx.fillStyle = nodeColor(n);
-    ctx.globalAlpha = alpha * (dormant ? 0.35 : 0.9);
+    ctx.globalAlpha = isSearchMatch ? 1 : alpha * (dormant ? 0.35 : 0.9);
     ctx.fill();
 
     // Core stroke ring
@@ -866,8 +888,8 @@ function draw() {
 
     // Label
     const label = n.node_type==='entry' ? n.label : n.label.slice(0,22)+(n.label.length>22?'…':'');
-    ctx.fillStyle = isSelected ? '#dde3f0' : '#5a6480';
-    ctx.font = '9px JetBrains Mono, monospace';
+    ctx.fillStyle = isSearchMatch ? '#fbbf24' : isSelected ? '#dde3f0' : '#5a6480';
+    ctx.font = `${isSearchMatch ? '600 ' : ''}9px JetBrains Mono, monospace`;
     ctx.fillText(label, n.x + br + 4, n.y + 3.5);
 
     ctx.restore();
@@ -1117,7 +1139,8 @@ function toggleFilter(key) {
 }
 function onSearch(val) {
   searchQuery = val.toLowerCase().trim();
-  renderGraph();
+  updateSearchFocus();
+  draw();
 }
 function onWeightChange(val) {
   weightThreshold = parseFloat(val);

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
@@ -232,9 +232,9 @@ def run_dashboard(
             self.end_headers()
             self.wfile.write(body)
 
-    server = HTTPServer((host, port), Handler)
+    server = ThreadingHTTPServer((host, port), Handler)
     logger.info("Flux dashboard running at http://%s:%d", host, port)
-    print(f"Flux Memory dashboard → http://{host}:{port}")
+    print(f"Flux Memory dashboard -> http://{host}:{port}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -1,24 +1,18 @@
-"""Minimal web dashboard for Flux Memory (Track 4 Step 4, §11.6).
+"""Interactive web dashboard for Flux Memory.
 
-Serves a single-page dashboard over HTTP. The page fetches:
-  GET /api/health     → flux_health() JSON
-  GET /api/graph      → export_json() node-link JSON
-  GET /api/clusters   → cluster_view() JSON
-
-Usage:
-    from flux.dashboard import run_dashboard
-    run_dashboard(store, host="127.0.0.1", port=7462)
-
-Or from the command line:
-    python -m flux.dashboard --db path/to/flux.db --port 7462
+Serves a single-page operational dashboard over HTTP. The page fetches:
+  GET /api/health     -> flux_health() JSON
+  GET /api/graph      -> export_json() node-link JSON
+  GET /api/clusters   -> cluster_view() JSON
+  GET /api/events     -> recent structured events
 """
 from __future__ import annotations
 
 import json
 import logging
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -26,500 +20,1185 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Flux Memory Dashboard</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Flux Memory - Dashboard</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
 <style>
   :root {
-    --bg: #0b0d12;
-    --surface: #151a22;
-    --surface-2: #1b2230;
-    --line: #2a3445;
-    --muted: #8a94a7;
-    --text: #edf2f7;
-    --teal: #2dd4bf;
-    --green: #74d99f;
-    --amber: #f2b84b;
+    --bg: #080a0e;
+    --surface: #0f1117;
+    --surface-2: #151923;
+    --surface-3: #1b2130;
+    --border: #222938;
+    --border-2: #2d3547;
+    --text: #e1e7f3;
+    --muted: #7b8498;
+    --dim: #4e566b;
+    --cyan: #22d3ee;
+    --cyan-dim: rgba(34, 211, 238, 0.12);
+    --green: #4ade80;
+    --green-dim: rgba(74, 222, 128, 0.12);
+    --amber: #fbbf24;
+    --amber-dim: rgba(251, 191, 36, 0.13);
     --rose: #fb7185;
+    --rose-dim: rgba(251, 113, 133, 0.13);
     --violet: #a78bfa;
-    --blue: #60a5fa;
+    --violet-dim: rgba(167, 139, 250, 0.12);
+    --radius: 8px;
+    --mono: "JetBrains Mono", "Fira Code", Consolas, monospace;
+    --ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
+
   * { box-sizing: border-box; }
+  html, body { height: 100%; }
   body {
     margin: 0;
     min-width: 320px;
     background: var(--bg);
     color: var(--text);
-    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: var(--ui);
+    font-size: 13px;
+    letter-spacing: 0;
+    overflow: hidden;
   }
-  header {
+  button, input { font: inherit; }
+  button { color: inherit; }
+  #app { display: flex; flex-direction: column; height: 100vh; }
+
+  #topbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 170px;
+  }
+  .brand-mark {
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 7px;
+    background: linear-gradient(180deg, #172033, #101723);
+    border: 1px solid var(--border-2);
+    color: var(--cyan);
+    font-weight: 800;
+  }
+  .brand-name { font-weight: 700; font-size: 14px; line-height: 1.15; }
+  .brand-sub { color: var(--muted); font-family: var(--mono); font-size: 10px; margin-top: 2px; }
+  .divider { width: 1px; align-self: stretch; background: var(--border); }
+  #status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 26px;
+    padding: 0 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .badge-healthy { background: var(--green-dim); color: var(--green); border: 1px solid rgba(74, 222, 128, 0.28); }
+  .badge-warning { background: var(--amber-dim); color: var(--amber); border: 1px solid rgba(251, 191, 36, 0.3); }
+  .badge-critical { background: var(--rose-dim); color: var(--rose); border: 1px solid rgba(251, 113, 133, 0.3); }
+  .pulse {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    animation: pulse 2s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.45); opacity: 0.55; }
+  }
+  #metrics-strip {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(86px, 1fr));
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+  }
+  .metric-pill {
+    min-width: 0;
+    padding: 5px 9px;
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+  }
+  .metric-pill .label {
+    color: var(--muted);
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .metric-pill .value {
+    margin-top: 1px;
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 16px;
+    font-weight: 800;
+    line-height: 1.2;
+  }
+  .value-cyan { color: var(--cyan) !important; }
+  .value-green { color: var(--green) !important; }
+  .value-amber { color: var(--amber) !important; }
+  .value-rose { color: var(--rose) !important; }
+  #topbar-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  #computed-at {
+    color: var(--dim);
+    font-family: var(--mono);
+    font-size: 10px;
+    white-space: nowrap;
+  }
+  .icon-btn {
+    display: inline-grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--muted);
+    cursor: pointer;
+  }
+  .icon-btn:hover { color: var(--text); border-color: var(--border-2); background: var(--surface-3); }
+  .icon-btn.active { color: var(--cyan); border-color: rgba(34, 211, 238, 0.35); background: var(--cyan-dim); }
+
+  #main { display: flex; flex: 1; min-height: 0; overflow: hidden; }
+  #graph-panel {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--border);
+  }
+  #graph-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  #search-box {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    width: 230px;
+    min-width: 160px;
+    height: 30px;
+    padding: 0 9px;
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+  #search-input {
+    width: 100%;
+    min-width: 0;
+    outline: none;
+    border: 0;
+    color: var(--text);
+    background: transparent;
+    font-size: 12px;
+  }
+  #search-input::placeholder { color: var(--dim); }
+  .filter-group { display: flex; align-items: center; gap: 4px; }
+  .filter-btn {
+    height: 28px;
+    padding: 0 9px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .filter-btn.active { color: var(--cyan); border-color: rgba(34, 211, 238, 0.35); background: var(--cyan-dim); }
+  .filter-btn.active.violet { color: var(--violet); border-color: rgba(167, 139, 250, 0.35); background: var(--violet-dim); }
+  .slider-group {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--muted);
+    font-size: 10px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+  }
+  #weight-slider { width: 92px; accent-color: var(--cyan); cursor: pointer; }
+  #weight-val { min-width: 30px; color: var(--cyan); font-family: var(--mono); font-size: 11px; }
+  #graph-container {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    background:
+      linear-gradient(rgba(34, 211, 238, 0.025) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(34, 211, 238, 0.025) 1px, transparent 1px),
+      #070a0f;
+    background-size: 32px 32px;
+    overflow: hidden;
+  }
+  #graph-svg { width: 100%; height: 100%; display: block; }
+  #graph-stats {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    gap: 8px;
+    padding: 6px 9px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: rgba(15, 17, 23, 0.82);
+    color: var(--muted);
+    font-family: var(--mono);
+    font-size: 10px;
+    backdrop-filter: blur(6px);
+  }
+  #graph-overlay {
+    position: absolute;
+    left: 12px;
+    bottom: 12px;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 6px 8px;
+    border-radius: var(--radius);
+    border: 1px solid rgba(34, 41, 56, 0.72);
+    background: rgba(15, 17, 23, 0.72);
+    backdrop-filter: blur(6px);
+  }
+  .legend-item { display: inline-flex; align-items: center; gap: 5px; color: var(--muted); font-size: 10px; }
+  .legend-dot { width: 8px; height: 8px; border-radius: 50%; }
+  #no-data-msg, #error-msg {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    color: var(--dim);
+    font-size: 13px;
+    text-align: center;
+    padding: 20px;
+  }
+  #error-msg { color: var(--rose); }
+
+  #right-panel {
+    width: 340px;
+    flex-shrink: 0;
+    background: var(--surface);
+    overflow: auto;
+  }
+  .r-section { border-bottom: 1px solid var(--border); }
+  .r-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 16px;
-    padding: 18px 24px;
-    background: #11161f;
-    border-bottom: 1px solid var(--line);
+    gap: 10px;
+    padding: 11px 14px;
+    cursor: pointer;
+    user-select: none;
   }
-  .brand { display: flex; align-items: center; gap: 12px; }
-  .brand-mark {
+  .r-title-wrap { display: flex; align-items: center; gap: 7px; min-width: 0; }
+  .r-title {
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .r-count {
+    min-width: 20px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--muted);
+    font-family: var(--mono);
+    font-size: 10px;
+    text-align: center;
+  }
+  .r-count.warn { color: var(--amber); border-color: rgba(251, 191, 36, 0.3); background: var(--amber-dim); }
+  .r-body { padding: 0 14px 13px; }
+  .chev { color: var(--dim); transition: transform 0.2s; }
+  .chev.open { transform: rotate(180deg); }
+
+  #inspector-empty {
+    padding: 22px 0;
+    color: var(--dim);
+    font-size: 12px;
+    text-align: center;
+  }
+  .node-head { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 11px; }
+  .node-icon {
     display: grid;
     place-items: center;
     width: 34px;
     height: 34px;
-    border-radius: 8px;
-    background: #1f2a38;
-    color: var(--amber);
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .node-label { color: var(--text); font-size: 12px; font-weight: 700; line-height: 1.35; word-break: break-word; }
+  .node-type { margin-top: 3px; color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .kv { display: flex; flex-direction: column; gap: 5px; }
+  .kv-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 5px 0;
+    border-bottom: 1px solid rgba(34, 41, 56, 0.72);
+  }
+  .kv-row:last-child { border-bottom: 0; }
+  .kv-key { color: var(--muted); font-size: 11px; flex-shrink: 0; }
+  .kv-val {
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 11px;
+    text-align: right;
+    word-break: break-all;
+  }
+  .tag {
+    display: inline-block;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
     font-weight: 800;
   }
-  h1 { margin: 0; font-size: 1.05rem; font-weight: 700; letter-spacing: 0; }
-  .updated { color: var(--muted); font-size: 0.82rem; margin-top: 2px; }
-  .header-actions { display: flex; align-items: center; gap: 10px; }
-  button {
-    border: 1px solid var(--line);
-    background: #19212c;
-    color: var(--text);
-    border-radius: 8px;
-    padding: 8px 10px;
-    font: inherit;
-    cursor: pointer;
+  .tag-cyan { background: var(--cyan-dim); color: var(--cyan); }
+  .tag-violet { background: var(--violet-dim); color: var(--violet); }
+  .tag-green { background: var(--green-dim); color: var(--green); }
+  .tag-amber { background: var(--amber-dim); color: var(--amber); }
+  .tag-rose { background: var(--rose-dim); color: var(--rose); }
+  .tag-dim { background: var(--surface-2); color: var(--muted); }
+
+  .warning-card {
+    padding: 9px 10px;
+    margin-bottom: 7px;
+    border-radius: var(--radius);
+    border: 1px solid rgba(251, 191, 36, 0.22);
+    background: rgba(251, 191, 36, 0.07);
   }
-  button:hover { border-color: #3b4a60; background: #202a38; }
-  main { padding: 18px; display: grid; gap: 16px; }
-  .metrics {
-    display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
-    gap: 12px;
-  }
-  .metric, .panel {
-    background: var(--surface);
-    border: 1px solid var(--line);
-    border-radius: 8px;
-  }
-  .metric { padding: 14px; min-height: 96px; }
-  .metric .label {
-    color: var(--muted);
-    font-size: 0.76rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-  .metric .value { font-size: 1.7rem; line-height: 1.2; font-weight: 750; margin-top: 8px; }
-  .metric .sub { color: var(--muted); font-size: 0.78rem; margin-top: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .value.good { color: var(--green); }
-  .value.warn { color: var(--amber); }
-  .value.bad { color: var(--rose); }
-  .value.info { color: var(--teal); }
-  .grid {
-    display: grid;
-    grid-template-columns: minmax(360px, 0.92fr) minmax(420px, 1.08fr);
-    gap: 16px;
-  }
-  .panel { overflow: hidden; }
-  .panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--line);
-    background: #171d27;
-  }
-  .panel h2 {
-    margin: 0;
-    font-size: 0.82rem;
-    font-weight: 750;
+  .warning-card:last-child { margin-bottom: 0; }
+  .warning-signal { color: var(--amber); font-family: var(--mono); font-size: 11px; font-weight: 800; }
+  .warning-msg { margin-top: 4px; color: #c5cede; font-size: 11px; line-height: 1.45; }
+  .warning-val { margin-top: 6px; color: var(--dim); font-family: var(--mono); font-size: 10px; }
+  .empty-row { color: var(--dim); font-size: 11px; padding: 8px 0; }
+
+  .health-group { margin-bottom: 11px; }
+  .health-group:last-child { margin-bottom: 0; }
+  .health-label {
+    margin-bottom: 5px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--border);
+    color: var(--dim);
+    font-size: 10px;
+    font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: #b4bed0;
   }
-  .badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 5px 9px;
-    border-radius: 999px;
-    font-size: 0.77rem;
-    font-weight: 800;
-    text-transform: uppercase;
+  .health-row { display: flex; align-items: center; gap: 7px; padding: 4px 0; }
+  .health-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
+  .health-key { flex: 1; min-width: 0; color: var(--muted); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .health-val { min-width: 52px; color: var(--text); font-family: var(--mono); font-size: 11px; text-align: right; }
+
+  .event-card {
+    padding: 7px 0;
+    border-bottom: 1px solid rgba(34, 41, 56, 0.72);
   }
-  .badge.healthy { background: rgba(116, 217, 159, 0.14); color: var(--green); }
-  .badge.warning { background: rgba(242, 184, 75, 0.16); color: var(--amber); }
-  .badge.critical { background: rgba(251, 113, 133, 0.16); color: var(--rose); }
-  .panel-body { padding: 14px 16px; }
-  table { width: 100%; border-collapse: collapse; font-size: 0.84rem; }
-  th {
-    text-align: left;
-    color: var(--muted);
-    padding: 0 8px 8px;
-    border-bottom: 1px solid var(--line);
-    font-size: 0.76rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+  .event-card:last-child { border-bottom: 0; }
+  .event-line { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .event-name { color: var(--text); font-family: var(--mono); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .event-time { color: var(--dim); font-family: var(--mono); font-size: 10px; flex-shrink: 0; }
+  .event-data { margin-top: 3px; color: var(--muted); font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+  #tooltip {
+    position: fixed;
+    z-index: 999;
+    pointer-events: none;
+    max-width: 280px;
+    padding: 9px 10px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border-2);
+    background: rgba(15, 17, 23, 0.97);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    transition: opacity 0.1s;
   }
-  td { padding: 9px 8px; border-bottom: 1px solid rgba(42, 52, 69, 0.52); }
-  tr:last-child td { border-bottom: 0; }
-  .signal-name { color: #dce6f6; }
-  .signal-value { color: #cbd5e1; font-variant-numeric: tabular-nums; }
-  .state-dot {
-    display: inline-block;
-    width: 9px;
-    height: 9px;
-    border-radius: 999px;
-    background: var(--rose);
+  .tt-title { color: var(--text); font-weight: 800; font-size: 12px; line-height: 1.35; margin-bottom: 5px; }
+  .tt-row { display: flex; justify-content: space-between; gap: 16px; line-height: 1.6; }
+  .tt-key { color: var(--muted); }
+  .tt-val { color: var(--text); font-family: var(--mono); }
+
+  ::-webkit-scrollbar { width: 6px; height: 6px; }
+  ::-webkit-scrollbar-thumb { background: var(--border-2); border-radius: 999px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+
+  @media (max-width: 1120px) {
+    #metrics-strip { grid-template-columns: repeat(3, minmax(86px, 1fr)); }
+    #computed-at { display: none; }
   }
-  .state-dot.ok { background: var(--green); }
-  .warnings { display: grid; gap: 10px; }
-  .warn-item {
-    border: 1px solid rgba(242, 184, 75, 0.22);
-    background: rgba(242, 184, 75, 0.08);
-    border-radius: 8px;
-    padding: 10px 12px;
-  }
-  .warn-title { color: var(--amber); font-size: 0.82rem; font-weight: 800; margin-bottom: 4px; }
-  .warn-text { color: #d7dee9; font-size: 0.84rem; line-height: 1.4; }
-  .muted { color: var(--muted); }
-  .graph-panel { min-height: 500px; }
-  .graph-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    color: var(--muted);
-    font-size: 0.78rem;
-  }
-  .pill {
-    border: 1px solid var(--line);
-    background: #121821;
-    color: #b8c2d4;
-    border-radius: 999px;
-    padding: 5px 8px;
-  }
-  #graph-canvas {
-    position: relative;
-    height: 430px;
-    background: #080b10;
-    border-top: 1px solid #101722;
-  }
-  #graph-svg { width: 100%; height: 100%; display: block; }
-  .empty-note {
-    position: absolute;
-    left: 18px;
-    bottom: 16px;
-    max-width: min(520px, calc(100% - 36px));
-    color: #aab5c7;
-    font-size: 0.86rem;
-    background: rgba(21, 26, 34, 0.88);
-    border: 1px solid var(--line);
-    border-radius: 8px;
-    padding: 10px 12px;
-  }
-  .legend {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 12px;
-    color: var(--muted);
-    font-size: 0.78rem;
-  }
-  .legend span { display: inline-flex; align-items: center; gap: 6px; }
-  .swatch { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
-  .span-2 { grid-column: 1 / -1; }
-  @media (max-width: 1100px) {
-    .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    .grid { grid-template-columns: 1fr; }
-  }
-  @media (max-width: 680px) {
-    header { align-items: flex-start; flex-direction: column; padding: 16px; }
-    main { padding: 12px; }
-    .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .metric .value { font-size: 1.35rem; }
-    #graph-canvas { height: 340px; }
+  @media (max-width: 860px) {
+    body { overflow: auto; }
+    #app { height: auto; min-height: 100vh; }
+    #topbar, #graph-toolbar { flex-wrap: wrap; }
+    #main { flex-direction: column; overflow: visible; }
+    #graph-panel { min-height: 620px; border-right: 0; border-bottom: 1px solid var(--border); }
+    #right-panel { width: auto; }
+    #metrics-strip { order: 4; flex-basis: 100%; grid-template-columns: repeat(2, minmax(86px, 1fr)); }
+    #search-box { flex: 1; width: auto; max-width: none; }
   }
 </style>
 </head>
 <body>
-<header>
-  <div class="brand">
-    <div class="brand-mark">F</div>
-    <div>
-      <h1>Flux Memory</h1>
-      <div class="updated" id="computed-at">Loading</div>
-    </div>
-  </div>
-  <div class="header-actions">
-    <div id="status-badge" class="badge warning">Loading</div>
-    <button id="refresh-button" type="button" title="Refresh dashboard">Refresh</button>
-  </div>
-</header>
-<main>
-  <section class="metrics" id="metrics"></section>
-
-  <section class="grid">
-    <div class="panel">
-      <div class="panel-header">
-        <h2>Health Signals</h2>
-      </div>
-      <div class="panel-body">
-        <table>
-          <thead><tr><th>Signal</th><th>Value</th><th>State</th></tr></thead>
-          <tbody id="signals-table"></tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="panel">
-      <div class="panel-header">
-        <h2>Warnings</h2>
-        <span class="pill" id="warning-count">0 active</span>
-      </div>
-      <div class="panel-body">
-        <div id="warnings-list" class="warnings"><span class="muted">None</span></div>
-      </div>
-    </div>
-  </section>
-
-  <section class="panel graph-panel span-2">
-    <div class="panel-header">
+<div id="app">
+  <header id="topbar">
+    <div class="brand">
+      <div class="brand-mark">F</div>
       <div>
-        <h2>Graph Overview</h2>
-        <div class="graph-meta" id="graph-stats"></div>
-      </div>
-      <div class="legend">
-        <span><i class="swatch" style="background:var(--teal)"></i>Entry</span>
-        <span><i class="swatch" style="background:var(--blue)"></i>Grain</span>
-        <span><i class="swatch" style="background:var(--amber)"></i>Core</span>
-        <span><i class="swatch" style="background:var(--green)"></i>Strong conduit</span>
+        <div class="brand-name">Flux Memory</div>
+        <div class="brand-sub">instance dashboard</div>
       </div>
     </div>
-    <div id="graph-canvas">
-      <svg id="graph-svg"></svg>
-      <div id="empty-note" class="empty-note" hidden></div>
+    <div id="status-badge" class="badge-warning"><span class="pulse"></span><span id="status-text">loading</span></div>
+    <div class="divider"></div>
+    <div id="metrics-strip">
+      <div class="metric-pill"><div class="label">Grains</div><div class="value value-cyan" id="m-grains">-</div></div>
+      <div class="metric-pill"><div class="label">Entries</div><div class="value" id="m-entries">-</div></div>
+      <div class="metric-pill"><div class="label">Conduits</div><div class="value value-green" id="m-conduits">-</div></div>
+      <div class="metric-pill"><div class="label">Embeddings</div><div class="value value-green" id="m-embeddings">-</div></div>
+      <div class="metric-pill"><div class="label">Retrieval</div><div class="value" id="m-retrieval">-</div></div>
+      <div class="metric-pill"><div class="label">Fallback</div><div class="value" id="m-fallback">-</div></div>
     </div>
-  </section>
-</main>
-<script>
-const fmt = new Intl.NumberFormat();
+    <div id="topbar-controls">
+      <span id="computed-at">not computed</span>
+      <button class="icon-btn" id="autorefresh-btn" type="button" title="Auto refresh" aria-label="Auto refresh">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v7h-7"/></svg>
+      </button>
+      <button class="icon-btn" id="refresh-btn" type="button" title="Refresh" aria-label="Refresh">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
+      </button>
+    </div>
+  </header>
 
-function safeNumber(value, digits = 3) {
-  const n = Number(value || 0);
+  <main id="main">
+    <section id="graph-panel">
+      <div id="graph-toolbar">
+        <div id="search-box">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+          <input id="search-input" type="text" placeholder="Search nodes">
+        </div>
+        <div class="filter-group">
+          <button class="filter-btn active" id="f-grain" type="button">Grains</button>
+          <button class="filter-btn violet active" id="f-entry" type="button">Entries</button>
+          <button class="filter-btn active" id="f-active" type="button">Active</button>
+          <button class="filter-btn" id="f-dormant" type="button">Dormant</button>
+        </div>
+        <div class="slider-group">
+          <label for="weight-slider">Min weight</label>
+          <input id="weight-slider" type="range" min="0" max="1" step="0.01" value="0">
+          <span id="weight-val">0.00</span>
+        </div>
+        <button class="icon-btn" id="pause-btn" type="button" title="Pause layout" aria-label="Pause layout">
+          <svg id="pause-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+        </button>
+        <button class="icon-btn" id="reset-btn" type="button" title="Reset view" aria-label="Reset view">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/></svg>
+        </button>
+      </div>
+      <div id="graph-container">
+        <svg id="graph-svg"></svg>
+        <div id="graph-stats"><span>nodes: <b id="gs-nodes">0</b></span><span>edges: <b id="gs-edges">0</b></span></div>
+        <div id="graph-overlay">
+          <span class="legend-item"><i class="legend-dot" style="background:var(--violet)"></i>Entry</span>
+          <span class="legend-item"><i class="legend-dot" style="background:var(--cyan)"></i>Working</span>
+          <span class="legend-item"><i class="legend-dot" style="background:#e0f2fe"></i>Core</span>
+          <span class="legend-item"><i class="legend-dot" style="background:var(--green)"></i>Strong</span>
+        </div>
+        <div id="no-data-msg">No graph data</div>
+        <div id="error-msg"></div>
+      </div>
+    </section>
+
+    <aside id="right-panel">
+      <section class="r-section">
+        <div class="r-header" data-section="inspector">
+          <div class="r-title-wrap"><span class="r-title">Inspector</span></div>
+          <svg class="chev open" id="chev-inspector" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+        </div>
+        <div class="r-body" id="body-inspector">
+          <div id="inspector-empty">No selection</div>
+          <div id="inspector-content" style="display:none"></div>
+        </div>
+      </section>
+
+      <section class="r-section">
+        <div class="r-header" data-section="warnings">
+          <div class="r-title-wrap"><span class="r-title">Warnings</span><span class="r-count warn" id="warnings-count">0</span></div>
+          <svg class="chev open" id="chev-warnings" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+        </div>
+        <div class="r-body" id="body-warnings"><div id="warnings-list"></div></div>
+      </section>
+
+      <section class="r-section">
+        <div class="r-header" data-section="health">
+          <div class="r-title-wrap"><span class="r-title">Health Signals</span></div>
+          <svg class="chev open" id="chev-health" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+        </div>
+        <div class="r-body" id="body-health"><div id="health-table"></div></div>
+      </section>
+
+      <section class="r-section">
+        <div class="r-header" data-section="events">
+          <div class="r-title-wrap"><span class="r-title">Recent Activity</span></div>
+          <svg class="chev open" id="chev-events" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
+        </div>
+        <div class="r-body" id="body-events"><div id="events-list"></div></div>
+      </section>
+    </aside>
+  </main>
+</div>
+
+<div id="tooltip">
+  <div class="tt-title" id="tt-title"></div>
+  <div id="tt-body"></div>
+</div>
+
+<script>
+let healthData = null;
+let graphData = null;
+let eventsData = [];
+let svg = null;
+let graphLayer = null;
+let simulation = null;
+let zoomBehavior = null;
+let nodeSelectionGlobal = null;
+let linkSelectionGlobal = null;
+let dashFrame = null;
+let dashOffset = 0;
+let autoRefreshTimer = null;
+let simulationPaused = false;
+let activeFilters = { grain: true, entry: true, active: true, dormant: false };
+let weightThreshold = 0;
+let searchQuery = "";
+let selectedNodeId = null;
+let selectedEdgeKey = null;
+
+const fmt = new Intl.NumberFormat();
+const tooltip = document.getElementById("tooltip");
+
+function esc(value) {
+  return String(value ?? "").replace(/[&<>"']/g, ch => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  }[ch]));
+}
+
+function formatNumber(value, digits = 2) {
+  const n = Number(value ?? 0);
+  if (!Number.isFinite(n)) return "-";
   return Number.isInteger(n) ? fmt.format(n) : n.toFixed(digits);
 }
 
-function metricCard(label, value, sub, tone) {
-  const el = document.createElement('div');
-  el.className = 'metric';
-  el.innerHTML = `<div class="label"></div><div class="value ${tone || ''}"></div><div class="sub"></div>`;
-  el.children[0].textContent = label;
-  el.children[1].textContent = value;
-  el.children[2].textContent = sub || '';
-  return el;
+function formatRate(value) {
+  const n = Number(value ?? 0);
+  if (!Number.isFinite(n)) return "-";
+  return `${Math.round(n * 100)}%`;
+}
+
+function edgeKey(edge) {
+  const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
+  const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
+  return `${sid}->${tid}:${edge.edge_type || "earned"}:${edge.weight || 0}`;
 }
 
 async function fetchJSON(url) {
-  const r = await fetch(url, { cache: 'no-store' });
-  if (!r.ok) throw new Error(`${url} returned ${r.status}`);
-  return r.json();
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  return response.json();
 }
 
-function renderMetrics(health, graph) {
-  const stats = graph.stats || {};
-  const sig = health.signals || {};
-  const metrics = document.getElementById('metrics');
-  metrics.innerHTML = '';
-  metrics.appendChild(metricCard('Grains', safeNumber(stats.grains), `${safeNumber(stats.active_grains)} active`, 'info'));
-  metrics.appendChild(metricCard('Entries', safeNumber(stats.entries), 'feature anchors', ''));
-  metrics.appendChild(metricCard('Conduits', safeNumber(stats.conduits), `${safeNumber(sig.avg_conduit_weight?.value)} avg weight`, stats.conduits > 0 ? 'good' : 'warn'));
-  metrics.appendChild(metricCard('Embeddings', safeNumber(stats.embeddings), 'vector fallback index', stats.embeddings > 0 ? 'good' : 'warn'));
-  metrics.appendChild(metricCard('Retrieval', `${safeNumber((sig.retrieval_success_rate?.value || 0) * 100, 1)}%`, 'success rate', ''));
-  metrics.appendChild(metricCard('Fallback', `${safeNumber((sig.fallback_trigger_rate?.value || 0) * 100, 1)}%`, 'trigger rate', (sig.fallback_trigger_rate?.value || 0) > 0.2 ? 'bad' : 'good'));
-}
-
-function renderHealth(data) {
-  document.getElementById('computed-at').textContent =
-    `Last computed ${data.computed_at || 'unknown'}`;
-
-  const badge = document.getElementById('status-badge');
-  const status = data.status || 'unknown';
-  badge.textContent = status;
-  badge.className = `badge ${status}`;
-
-  const tbody = document.getElementById('signals-table');
-  tbody.innerHTML = '';
-  for (const [name, sig] of Object.entries(data.signals || {})) {
-    const tr = document.createElement('tr');
-    const nameCell = document.createElement('td');
-    const valueCell = document.createElement('td');
-    const stateCell = document.createElement('td');
-    nameCell.className = 'signal-name';
-    valueCell.className = 'signal-value';
-    nameCell.textContent = name;
-    valueCell.textContent = safeNumber(sig.value);
-    const dot = document.createElement('span');
-    dot.className = `state-dot ${sig.healthy ? 'ok' : ''}`;
-    dot.title = sig.healthy ? 'healthy' : 'warning';
-    stateCell.appendChild(dot);
-    tr.append(nameCell, valueCell, stateCell);
-    tbody.appendChild(tr);
-  }
-
-  const wlist = document.getElementById('warnings-list');
-  const count = document.getElementById('warning-count');
-  const warns = data.active_warnings || [];
-  count.textContent = `${warns.length} active`;
-  wlist.innerHTML = '';
-  if (warns.length === 0) {
-    const empty = document.createElement('span');
-    empty.className = 'muted';
-    empty.textContent = 'None';
-    wlist.appendChild(empty);
-    return;
-  }
-  warns.forEach(w => {
-    const item = document.createElement('div');
-    item.className = 'warn-item';
-    const title = document.createElement('div');
-    title.className = 'warn-title';
-    title.textContent = w.signal || 'warning';
-    const text = document.createElement('div');
-    text.className = 'warn-text';
-    text.textContent = w.suggestion || '';
-    item.append(title, text);
-    wlist.appendChild(item);
-  });
-}
-
-function renderGraph(data) {
-  const nodes = data.nodes || [];
-  const links = data.links || [];
-  const stats = data.stats || {};
-  const graphStats = document.getElementById('graph-stats');
-  graphStats.innerHTML = '';
-  [
-    `${safeNumber(stats.grains || 0)} grains`,
-    `${safeNumber(stats.entries || 0)} entries`,
-    `${safeNumber(stats.conduits || 0)} conduits`,
-    `${safeNumber(stats.embeddings || 0)} embeddings`
-  ].forEach(text => {
-    const pill = document.createElement('span');
-    pill.className = 'pill';
-    pill.textContent = text;
-    graphStats.appendChild(pill);
-  });
-
-  const svg = document.getElementById('graph-svg');
-  const note = document.getElementById('empty-note');
-  const W = Math.max(svg.clientWidth || 960, 480);
-  const H = Math.max(svg.clientHeight || 430, 300);
-  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
-  svg.innerHTML = '';
-  note.hidden = true;
-
-  if (nodes.length === 0) {
-    note.hidden = false;
-    note.textContent = 'No graph data is stored yet.';
-    return;
-  }
-
-  const degree = {};
-  links.forEach(l => {
-    degree[l.source] = (degree[l.source] || 0) + 1;
-    degree[l.target] = (degree[l.target] || 0) + 1;
-  });
-
-  const entries = nodes.filter(n => n.node_type === 'entry');
-  const grains = nodes.filter(n => n.node_type !== 'entry');
-  const pos = {};
-
-  if (links.length === 0) {
-    note.hidden = false;
-    note.textContent = 'No conduits are stored, so grains are currently isolated.';
-    layoutBand(entries, W * 0.22, W * 0.14, H, pos);
-    layoutBand(grains, W * 0.67, W * 0.26, H, pos);
-  } else {
-    layoutLinked(nodes, links, degree, W, H, pos);
-  }
-
-  links.forEach(l => {
-    const s = pos[l.source], t = pos[l.target];
-    if (!s || !t) return;
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    const midX = (s.x + t.x) / 2;
-    const midY = (s.y + t.y) / 2 - 18;
-    const w = Math.max(0.8, (l.effective_weight || 0.3) * 5);
-    const color = l.effective_weight > 0.5 ? 'var(--green)' : l.effective_weight > 0.25 ? 'var(--amber)' : 'var(--rose)';
-    path.setAttribute('d', `M ${s.x} ${s.y} Q ${midX} ${midY} ${t.x} ${t.y}`);
-    path.setAttribute('fill', 'none');
-    path.setAttribute('stroke', color);
-    path.setAttribute('stroke-width', w);
-    path.setAttribute('opacity', '0.58');
-    svg.appendChild(path);
-  });
-
-  nodes.forEach(n => {
-    const p = pos[n.id];
-    if (!p) return;
-    const isEntry = n.node_type === 'entry';
-    const isCore = n.decay_class === 'core';
-    const r = Math.min(12, 4.5 + Math.sqrt(degree[n.id] || 0) * 1.5 + (isEntry ? 1 : 0));
-    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-    circle.setAttribute('cx', p.x);
-    circle.setAttribute('cy', p.y);
-    circle.setAttribute('r', r);
-    circle.setAttribute('fill', isEntry ? 'var(--teal)' : isCore ? 'var(--amber)' : 'var(--blue)');
-    circle.setAttribute('stroke', '#0b0d12');
-    circle.setAttribute('stroke-width', '1.5');
-    circle.setAttribute('opacity', n.status === 'dormant' ? '0.34' : '0.88');
-    const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-    title.textContent = n.label || n.id;
-    circle.appendChild(title);
-    svg.appendChild(circle);
-  });
-}
-
-function layoutBand(items, centerX, radiusX, height, pos) {
-  const rows = Math.max(1, Math.ceil(Math.sqrt(items.length || 1)));
-  items.forEach((n, i) => {
-    const row = i % rows;
-    const col = Math.floor(i / rows);
-    const x = centerX + ((col % 6) - 2.5) * Math.max(18, radiusX / 4);
-    const y = 54 + row * ((height - 108) / Math.max(rows - 1, 1));
-    pos[n.id] = { x, y };
-  });
-}
-
-function layoutLinked(nodes, links, degree, W, H, pos) {
-  const sorted = [...nodes].sort((a, b) => (degree[b.id] || 0) - (degree[a.id] || 0));
-  sorted.forEach((n, i) => {
-    const ring = i < 10 ? 0 : i < 40 ? 1 : 2;
-    const ringIndex = ring === 0 ? i : ring === 1 ? i - 10 : i - 40;
-    const ringCount = ring === 0 ? Math.min(10, sorted.length) : ring === 1 ? Math.min(30, sorted.length - 10) : Math.max(1, sorted.length - 40);
-    const angle = (2 * Math.PI * ringIndex) / Math.max(ringCount, 1) + ring * 0.26;
-    const rx = W * (0.16 + ring * 0.13);
-    const ry = H * (0.15 + ring * 0.12);
-    pos[n.id] = { x: W / 2 + rx * Math.cos(angle), y: H / 2 + ry * Math.sin(angle) };
-  });
-}
-
-async function refresh() {
+async function fetchAll() {
+  const error = document.getElementById("error-msg");
+  error.style.display = "none";
   try {
-    const [health, graph] = await Promise.all([
-      fetchJSON('/api/health'),
-      fetchJSON('/api/graph'),
+    const [health, graph, events] = await Promise.all([
+      fetchJSON("/api/health"),
+      fetchJSON("/api/graph"),
+      fetchJSON("/api/events?limit=18").catch(() => ({ events: [] })),
     ]);
-    renderMetrics(health, graph);
-    renderHealth(health);
-    renderGraph(graph);
-  } catch (e) {
-    console.error('refresh failed', e);
+    healthData = health;
+    graphData = graph;
+    eventsData = events.events || [];
+    renderHealth();
+    renderEvents();
+    renderGraph();
+  } catch (err) {
+    console.error(err);
+    error.textContent = `Dashboard API unavailable: ${err.message}`;
+    error.style.display = "flex";
   }
 }
 
-document.getElementById('refresh-button').addEventListener('click', refresh);
-refresh();
-setInterval(refresh, 15000);
+function renderHealth() {
+  if (!healthData) return;
+  const status = healthData.status || "warning";
+  const badge = document.getElementById("status-badge");
+  const badgeStatus = ["healthy", "warning", "critical"].includes(status) ? status : "warning";
+  badge.className = `badge-${badgeStatus}`;
+  document.getElementById("status-text").textContent = status;
+
+  const computedAt = healthData.computed_at ? new Date(healthData.computed_at) : null;
+  document.getElementById("computed-at").textContent =
+    computedAt && !Number.isNaN(computedAt.valueOf()) ? computedAt.toLocaleTimeString() : "not computed";
+
+  const stats = graphData?.stats || {};
+  const signals = healthData.signals || {};
+  setMetric("m-grains", stats.grains, "value-cyan");
+  setMetric("m-entries", stats.entries, "");
+  setMetric("m-conduits", stats.conduits, stats.conduits > 0 ? "value-green" : "value-amber");
+  setMetric("m-embeddings", stats.embeddings, stats.embeddings > 0 ? "value-green" : "value-amber");
+  setMetric("m-retrieval", formatRate(signals.retrieval_success_rate?.value), "");
+  setMetric("m-fallback", formatRate(signals.fallback_trigger_rate?.value), (signals.fallback_trigger_rate?.value || 0) > 0.2 ? "value-rose" : "value-green");
+
+  const warnings = healthData.active_warnings || [];
+  document.getElementById("warnings-count").textContent = warnings.length;
+  const warningsList = document.getElementById("warnings-list");
+  warningsList.innerHTML = warnings.length ? warnings.map(w => `
+    <div class="warning-card">
+      <div class="warning-signal">${esc(w.signal)}</div>
+      <div class="warning-msg">${esc(w.suggestion)}</div>
+      <div class="warning-val">value ${esc(w.current_value)} / range ${esc(w.healthy_range)} / ${esc(w.severity)}</div>
+    </div>`).join("") : `<div class="empty-row">None</div>`;
+
+  const groups = {
+    "Retrieval": ["retrieval_success_rate", "avg_hops_per_retrieval", "fallback_trigger_rate"],
+    "Feedback": ["feedback_compliance_rate", "promotion_events", "shortcut_creation_rate"],
+    "Graph": ["highway_count", "highway_growth_rate", "orphan_rate", "core_grain_count", "avg_conduit_weight"],
+    "Decay": ["dormant_grain_rate", "conduit_dissolution_rate", "avg_weight_drop_on_failure"],
+  };
+  let healthHtml = "";
+  for (const [group, keys] of Object.entries(groups)) {
+    healthHtml += `<div class="health-group"><div class="health-label">${group}</div>`;
+    for (const key of keys) {
+      const signal = signals[key];
+      if (!signal) continue;
+      const value = key.includes("rate") ? formatRate(signal.value) : formatNumber(signal.value);
+      healthHtml += `
+        <div class="health-row">
+          <span class="health-dot" style="background:${signal.healthy ? "var(--green)" : "var(--rose)"}"></span>
+          <span class="health-key" title="${esc(key)}">${esc(key.replaceAll("_", " "))}</span>
+          <span class="health-val" style="color:${signal.healthy ? "var(--text)" : "var(--rose)"}">${value}</span>
+        </div>`;
+    }
+    healthHtml += `</div>`;
+  }
+  document.getElementById("health-table").innerHTML = healthHtml;
+}
+
+function setMetric(id, value, tone) {
+  const el = document.getElementById(id);
+  el.className = `value ${tone || ""}`;
+  el.textContent = typeof value === "string" ? value : formatNumber(value, 0);
+}
+
+function renderEvents() {
+  const list = document.getElementById("events-list");
+  if (!eventsData.length) {
+    list.innerHTML = `<div class="empty-row">None</div>`;
+    return;
+  }
+  list.innerHTML = eventsData.map(e => {
+    const t = e.timestamp ? new Date(e.timestamp.replace("Z", "+00:00")) : null;
+    const time = t && !Number.isNaN(t.valueOf()) ? t.toLocaleTimeString() : "";
+    const detail = eventSummary(e.data || {});
+    return `<div class="event-card">
+      <div class="event-line"><span class="event-name">${esc(e.category)}/${esc(e.event)}</span><span class="event-time">${esc(time)}</span></div>
+      <div class="event-data">${esc(detail)}</div>
+    </div>`;
+  }).join("");
+}
+
+function eventSummary(data) {
+  const entries = Object.entries(data).filter(([k, v]) => v !== null && v !== undefined);
+  if (!entries.length) return "";
+  return entries.slice(0, 4).map(([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : v}`).join(" | ");
+}
+
+function nodeColor(node) {
+  if (node.status === "dormant") return "#263244";
+  if (node.node_type === "entry") return "#a78bfa";
+  if (node.decay_class === "core") return "#e0f2fe";
+  if (node.decay_class === "ephemeral") return "#0e7490";
+  return "#22d3ee";
+}
+
+function nodeRadius(node) {
+  if (node.node_type === "entry") return 6;
+  if (node.decay_class === "core") return 10;
+  return 8;
+}
+
+function edgeColor(edge) {
+  if (edge.direction === "bidirectional") return "#a78bfa";
+  if ((edge.effective_weight ?? edge.weight ?? 0) >= 0.55) return "#4ade80";
+  if (edge.decay_class === "core") return "#38bdf8";
+  return "#1e4a62";
+}
+
+function getVisibleNodes() {
+  if (!graphData) return [];
+  return (graphData.nodes || []).filter(node => {
+    const isEntry = node.node_type === "entry";
+    const typeOk = isEntry ? activeFilters.entry : activeFilters.grain;
+    const status = node.status || "active";
+    const statusOk = status === "dormant" ? activeFilters.dormant : activeFilters.active;
+    const haystack = `${node.label || ""} ${node.id || ""} ${node.feature || ""}`.toLowerCase();
+    const searchOk = !searchQuery || haystack.includes(searchQuery);
+    return typeOk && statusOk && searchOk;
+  });
+}
+
+function getVisibleLinks(nodeIds) {
+  if (!graphData) return [];
+  const visible = new Set(nodeIds);
+  return (graphData.links || []).filter(link => {
+    const source = typeof link.source === "object" ? link.source.id : link.source;
+    const target = typeof link.target === "object" ? link.target.id : link.target;
+    const weight = Number(link.effective_weight ?? link.weight ?? 0);
+    return visible.has(source) && visible.has(target) && weight >= weightThreshold;
+  });
+}
+
+function renderGraph() {
+  const container = document.getElementById("graph-container");
+  const error = document.getElementById("error-msg");
+  if (!window.d3) {
+    error.textContent = "Graph renderer unavailable: D3 did not load";
+    error.style.display = "flex";
+    return;
+  }
+
+  if (simulation) simulation.stop();
+  if (dashFrame) cancelAnimationFrame(dashFrame);
+
+  const width = Math.max(container.clientWidth, 360);
+  const height = Math.max(container.clientHeight, 360);
+  d3.select("#graph-svg").selectAll("*").remove();
+  svg = d3.select("#graph-svg").attr("width", width).attr("height", height);
+
+  if (!graphData || !(graphData.nodes || []).length) {
+    document.getElementById("no-data-msg").style.display = "flex";
+    document.getElementById("gs-nodes").textContent = "0";
+    document.getElementById("gs-edges").textContent = "0";
+    return;
+  }
+  document.getElementById("no-data-msg").style.display = "none";
+
+  const visibleNodes = getVisibleNodes();
+  const visibleLinks = getVisibleLinks(visibleNodes.map(n => n.id));
+  document.getElementById("gs-nodes").textContent = visibleNodes.length;
+  document.getElementById("gs-edges").textContent = visibleLinks.length;
+
+  const nodes = visibleNodes.map(n => ({ ...n }));
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  const links = visibleLinks.map(link => ({
+    ...link,
+    source: nodeMap.get(typeof link.source === "object" ? link.source.id : link.source),
+    target: nodeMap.get(typeof link.target === "object" ? link.target.id : link.target),
+  })).filter(link => link.source && link.target);
+
+  const defs = svg.append("defs");
+  ["forward", "bidirectional", "selected"].forEach(type => {
+    defs.append("marker")
+      .attr("id", `arrow-${type}`)
+      .attr("viewBox", "0 -4 8 8")
+      .attr("refX", 15)
+      .attr("refY", 0)
+      .attr("markerWidth", 6)
+      .attr("markerHeight", 6)
+      .attr("orient", "auto")
+      .append("path")
+      .attr("d", "M0,-4L8,0L0,4")
+      .attr("fill", type === "selected" ? "#22d3ee" : type === "bidirectional" ? "#a78bfa" : "#1e4a62");
+  });
+
+  zoomBehavior = d3.zoom().scaleExtent([0.12, 5]).on("zoom", event => graphLayer.attr("transform", event.transform));
+  svg.call(zoomBehavior);
+  graphLayer = svg.append("g");
+
+  const linkSelection = graphLayer.append("g")
+    .attr("class", "links")
+    .selectAll("line")
+    .data(links, edgeKey)
+    .enter()
+    .append("line")
+    .attr("stroke", edgeColor)
+    .attr("stroke-width", d => Math.max(0.65, Number(d.effective_weight ?? d.weight ?? 0.25) * 3.2))
+    .attr("stroke-opacity", 0.72)
+    .attr("marker-end", d => `url(#arrow-${d.direction === "bidirectional" ? "bidirectional" : "forward"})`)
+    .attr("stroke-dasharray", d => d.direction === "bidirectional" ? "4 5" : d.decay_class === "core" ? "6 4" : null)
+    .style("cursor", "pointer")
+    .on("mouseenter", showEdgeTooltip)
+    .on("mousemove", moveTooltip)
+    .on("mouseleave", hideTooltip)
+    .on("click", (event, d) => { event.stopPropagation(); selectEdge(d); });
+
+  const nodeSelection = graphLayer.append("g")
+    .attr("class", "nodes")
+    .selectAll("g")
+    .data(nodes, d => d.id)
+    .enter()
+    .append("g")
+    .attr("class", "graph-node")
+    .style("cursor", "pointer")
+    .call(d3.drag().on("start", dragStart).on("drag", dragged).on("end", dragEnd))
+    .on("mouseenter", showNodeTooltip)
+    .on("mousemove", moveTooltip)
+    .on("mouseleave", hideTooltip)
+    .on("click", (event, d) => { event.stopPropagation(); selectNode(d); });
+
+  nodeSelection.filter(d => d.decay_class === "core").append("circle")
+    .attr("r", d => nodeRadius(d) + 8)
+    .attr("fill", "#22d3ee")
+    .attr("fill-opacity", 0.08)
+    .attr("stroke", "#22d3ee")
+    .attr("stroke-opacity", 0.38)
+    .attr("stroke-width", 2);
+
+  nodeSelection.append("circle")
+    .attr("class", "node-main")
+    .attr("r", nodeRadius)
+    .attr("fill", nodeColor)
+    .attr("fill-opacity", d => d.status === "dormant" ? 0.38 : 0.92)
+    .attr("stroke", d => selectedNodeId === d.id ? "#22d3ee" : d.decay_class === "core" ? "#7dd3fc" : "transparent")
+    .attr("stroke-width", d => selectedNodeId === d.id ? 2.5 : 1.5);
+
+  nodeSelection.append("text")
+    .text(d => d.node_type === "entry" ? d.label : truncate(d.label || d.id, 24))
+    .attr("x", d => nodeRadius(d) + 5)
+    .attr("y", 4)
+    .attr("fill", "#8d99ad")
+    .attr("font-size", "9px")
+    .attr("font-family", "JetBrains Mono, Consolas, monospace")
+    .attr("pointer-events", "none");
+
+  simulation = d3.forceSimulation(nodes)
+    .force("link", d3.forceLink(links).id(d => d.id).distance(d => 58 + (1 - Number(d.effective_weight ?? 0.3)) * 74).strength(0.42))
+    .force("charge", d3.forceManyBody().strength(-175).distanceMax(320))
+    .force("center", d3.forceCenter(width / 2, height / 2))
+    .force("collision", d3.forceCollide(d => nodeRadius(d) + 10))
+    .alphaDecay(0.018)
+    .alphaMin(0.001)
+    .on("tick", () => {
+      linkSelection
+        .attr("x1", d => d.source.x)
+        .attr("y1", d => d.source.y)
+        .attr("x2", d => d.target.x)
+        .attr("y2", d => d.target.y);
+      nodeSelection.attr("transform", d => `translate(${d.x},${d.y})`);
+    });
+
+  animateDashes(linkSelection);
+  nodeSelectionGlobal = nodeSelection;
+  linkSelectionGlobal = linkSelection;
+  svg.on("click", () => clearSelection());
+  if (simulationPaused) simulation.stop();
+}
+
+function animateDashes(linkSelection) {
+  function loop() {
+    dashOffset -= 0.35;
+    linkSelection.attr("stroke-dashoffset", dashOffset);
+    dashFrame = requestAnimationFrame(loop);
+  }
+  loop();
+}
+
+function dragStart(event, d) {
+  if (!event.active && simulation && !simulationPaused) simulation.alphaTarget(0.25).restart();
+  d.fx = d.x;
+  d.fy = d.y;
+}
+function dragged(event, d) {
+  d.fx = event.x;
+  d.fy = event.y;
+}
+function dragEnd(event, d) {
+  if (!event.active && simulation && !simulationPaused) simulation.alphaTarget(0.015);
+  d.fx = null;
+  d.fy = null;
+}
+
+function showTooltip(event, title, rows) {
+  document.getElementById("tt-title").textContent = title;
+  document.getElementById("tt-body").innerHTML = rows.map(([key, value]) =>
+    `<div class="tt-row"><span class="tt-key">${esc(key)}</span><span class="tt-val">${esc(value)}</span></div>`
+  ).join("");
+  tooltip.style.opacity = "1";
+  positionTooltip(event.clientX, event.clientY);
+}
+function positionTooltip(x, y) {
+  const rect = tooltip.getBoundingClientRect();
+  tooltip.style.left = `${x + 14 + rect.width > window.innerWidth ? x - rect.width - 12 : x + 14}px`;
+  tooltip.style.top = `${Math.min(y - 10, window.innerHeight - rect.height - 10)}px`;
+}
+function moveTooltip(event) { positionTooltip(event.clientX, event.clientY); }
+function hideTooltip() { tooltip.style.opacity = "0"; }
+function showNodeTooltip(event, node) {
+  showTooltip(event, truncate(node.label || node.id, 72), [
+    ["type", node.node_type],
+    ["status", node.status || "-"],
+    ["decay", node.decay_class || "-"],
+    ["provenance", node.provenance || "-"],
+    ["context", node.context_spread ?? "-"],
+  ]);
+}
+function showEdgeTooltip(event, edge) {
+  const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
+  const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
+  showTooltip(event, `${sid.slice(0, 8)} -> ${tid.slice(0, 8)}`, [
+    ["weight", formatNumber(edge.weight, 4)],
+    ["effective", formatNumber(edge.effective_weight, 4)],
+    ["direction", edge.direction || "-"],
+    ["decay", edge.decay_class || "-"],
+    ["uses", edge.use_count ?? 0],
+  ]);
+}
+
+function selectNode(node) {
+  selectedNodeId = node.id;
+  selectedEdgeKey = null;
+  const neighbors = new Set([node.id]);
+  linkSelectionGlobal?.each(function(edge) {
+    if (!edge || !edge.source || !edge.target) return;
+    const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
+    const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
+    if (sid === node.id || tid === node.id) {
+      neighbors.add(sid);
+      neighbors.add(tid);
+    }
+  });
+  nodeSelectionGlobal?.attr("opacity", d => neighbors.has(d.id) ? 1 : 0.16);
+  linkSelectionGlobal?.attr("stroke-opacity", edge => {
+    if (!edge || !edge.source || !edge.target) return 0.72;
+    const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
+    const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
+    return sid === node.id || tid === node.id ? 1 : 0.06;
+  });
+  nodeSelectionGlobal?.select("circle.node-main")
+    .attr("stroke", d => d.id === node.id ? "#22d3ee" : d.decay_class === "core" ? "#7dd3fc" : "transparent")
+    .attr("stroke-width", d => d.id === node.id ? 2.5 : 1.5);
+  renderInspector(node, "node");
+}
+
+function selectEdge(edge) {
+  selectedEdgeKey = edgeKey(edge);
+  selectedNodeId = null;
+  nodeSelectionGlobal?.attr("opacity", 0.25);
+  linkSelectionGlobal?.attr("stroke-opacity", e => edgeKey(e) === selectedEdgeKey ? 1 : 0.08);
+  renderInspector(edge, "edge");
+}
+
+function clearSelection() {
+  selectedNodeId = null;
+  selectedEdgeKey = null;
+  nodeSelectionGlobal?.attr("opacity", 1);
+  linkSelectionGlobal?.attr("stroke-opacity", 0.72);
+  nodeSelectionGlobal?.select("circle.node-main")
+    .attr("stroke", d => d.decay_class === "core" ? "#7dd3fc" : "transparent")
+    .attr("stroke-width", 1.5);
+  document.getElementById("inspector-empty").style.display = "";
+  document.getElementById("inspector-content").style.display = "none";
+}
+
+function tag(value) {
+  const v = String(value ?? "-");
+  const cls = v === "entry" ? "violet" : v === "core" || v === "active" ? "cyan" : v === "dormant" ? "rose" : v === "bidirectional" ? "violet" : "dim";
+  return `<span class="tag tag-${cls}">${esc(v)}</span>`;
+}
+
+function renderInspector(item, type) {
+  document.getElementById("inspector-empty").style.display = "none";
+  const container = document.getElementById("inspector-content");
+  container.style.display = "";
+  if (type === "node") {
+    const color = nodeColor(item);
+    container.innerHTML = `
+      <div class="node-head">
+        <div class="node-icon" style="background:${color}22;border:1px solid ${color}55">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="${color}"><circle cx="12" cy="12" r="${item.node_type === "entry" ? 6 : 8}"/></svg>
+        </div>
+        <div>
+          <div class="node-label">${esc(item.label || item.id)}</div>
+          <div class="node-type">${esc(item.node_type)}${item.decay_class ? " / " + esc(item.decay_class) : ""}</div>
+        </div>
+      </div>
+      <div class="kv">
+        ${kv("ID", item.id)}
+        ${kv("Type", tag(item.node_type), true)}
+        ${item.status ? kv("Status", tag(item.status), true) : ""}
+        ${item.decay_class ? kv("Decay", tag(item.decay_class), true) : ""}
+        ${item.provenance ? kv("Provenance", tag(item.provenance), true) : ""}
+        ${item.context_spread !== undefined ? kv("Context", item.context_spread) : ""}
+        ${item.feature ? kv("Feature", item.feature) : ""}
+      </div>`;
+  } else {
+    const sid = typeof item.source === "object" ? item.source.id : item.source;
+    const tid = typeof item.target === "object" ? item.target.id : item.target;
+    const sourceLabel = typeof item.source === "object" ? item.source.label : sid;
+    const targetLabel = typeof item.target === "object" ? item.target.label : tid;
+    container.innerHTML = `
+      <div class="node-label" style="margin-bottom:10px">${esc(truncate(sourceLabel || sid, 46))}<br><span style="color:var(--dim)">to</span><br>${esc(truncate(targetLabel || tid, 46))}</div>
+      <div class="kv">
+        ${kv("Weight", formatNumber(item.weight, 4))}
+        ${kv("Effective", formatNumber(item.effective_weight, 4))}
+        ${kv("Direction", tag(item.direction || "forward"), true)}
+        ${kv("Decay", tag(item.decay_class || "working"), true)}
+        ${kv("Use count", item.use_count ?? 0)}
+        ${kv("Edge type", tag(item.edge_type || "earned"), true)}
+      </div>`;
+  }
+}
+
+function kv(key, value, raw = false) {
+  return `<div class="kv-row"><span class="kv-key">${esc(key)}</span><span class="kv-val">${raw ? value : esc(value)}</span></div>`;
+}
+
+function truncate(value, max) {
+  const text = String(value ?? "");
+  return text.length > max ? `${text.slice(0, max - 1)}...` : text;
+}
+
+function toggleFilter(key) {
+  activeFilters[key] = !activeFilters[key];
+  document.getElementById(`f-${key}`).classList.toggle("active", activeFilters[key]);
+  clearSelection();
+  renderGraph();
+}
+
+function onSearch(value) {
+  searchQuery = value.toLowerCase().trim();
+  renderGraph();
+}
+
+function onWeightChange(value) {
+  weightThreshold = Number(value);
+  document.getElementById("weight-val").textContent = weightThreshold.toFixed(2);
+  clearSelection();
+  renderGraph();
+}
+
+function toggleSimulation() {
+  simulationPaused = !simulationPaused;
+  document.getElementById("pause-btn").classList.toggle("active", simulationPaused);
+  const icon = document.getElementById("pause-icon");
+  if (simulationPaused) {
+    simulation?.stop();
+    if (dashFrame) cancelAnimationFrame(dashFrame);
+    dashFrame = null;
+    icon.innerHTML = `<polygon points="5 3 19 12 5 21 5 3"/>`;
+  } else {
+    simulation?.alphaTarget(0.025).restart();
+    icon.innerHTML = `<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>`;
+    renderGraph();
+  }
+}
+
+function resetView() {
+  if (!svg || !zoomBehavior) return;
+  svg.transition().duration(450).call(zoomBehavior.transform, d3.zoomIdentity);
+}
+
+function toggleAutoRefresh() {
+  const btn = document.getElementById("autorefresh-btn");
+  if (autoRefreshTimer) {
+    clearInterval(autoRefreshTimer);
+    autoRefreshTimer = null;
+    btn.classList.remove("active");
+  } else {
+    autoRefreshTimer = setInterval(fetchAll, 30000);
+    btn.classList.add("active");
+  }
+}
+
+function toggleSection(id) {
+  const body = document.getElementById(`body-${id}`);
+  const chev = document.getElementById(`chev-${id}`);
+  const open = body.style.display === "none";
+  body.style.display = open ? "" : "none";
+  chev?.classList.toggle("open", open);
+}
+
+document.getElementById("refresh-btn").addEventListener("click", fetchAll);
+document.getElementById("autorefresh-btn").addEventListener("click", toggleAutoRefresh);
+document.getElementById("pause-btn").addEventListener("click", toggleSimulation);
+document.getElementById("reset-btn").addEventListener("click", resetView);
+document.getElementById("search-input").addEventListener("input", event => onSearch(event.target.value));
+document.getElementById("weight-slider").addEventListener("input", event => onWeightChange(event.target.value));
+["grain", "entry", "active", "dormant"].forEach(key => {
+  document.getElementById(`f-${key}`).addEventListener("click", () => toggleFilter(key));
+});
+document.querySelectorAll(".r-header").forEach(header => {
+  header.addEventListener("click", () => toggleSection(header.dataset.section));
+});
+window.addEventListener("resize", () => { if (graphData) renderGraph(); });
+window.addEventListener("load", fetchAll);
 </script>
 </body>
 </html>
 """
+
+
+def _recent_events(store: Any, limit: int = 25) -> dict[str, list[dict[str, Any]]]:
+    safe_limit = max(1, min(int(limit), 100))
+    rows = store.conn.execute(
+        """
+        SELECT timestamp, category, event, trace_id, data
+        FROM events
+        WHERE category != 'health'
+        ORDER BY timestamp DESC
+        LIMIT ?
+        """,
+        (safe_limit,),
+    ).fetchall()
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            data = json.loads(row["data"] or "{}")
+        except json.JSONDecodeError:
+            data = {}
+        events.append({
+            "timestamp": row["timestamp"],
+            "category": row["category"],
+            "event": row["event"],
+            "trace_id": row["trace_id"],
+            "data": data,
+        })
+    return {"events": events}
 
 
 def run_dashboard(
@@ -529,25 +1208,37 @@ def run_dashboard(
     cfg: Any = None,
 ) -> None:
     """Start the HTTP dashboard server (blocking). Ctrl+C to stop."""
-    from .visualization import export_json, cluster_view
     from .health import flux_health
+    from .visualization import cluster_view, export_json
 
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, fmt, *args):
             logger.debug(fmt, *args)
 
         def do_GET(self):
-            if self.path == "/" or self.path == "/index.html":
+            parsed = urlparse(self.path)
+            path = parsed.path
+            if path == "/" or path == "/index.html":
                 self._send(200, "text/html; charset=utf-8", _DASHBOARD_HTML.encode())
-            elif self.path == "/api/health":
+            elif path == "/api/health":
                 data = flux_health(store, cfg) if cfg else flux_health(store)
                 self._send(200, "application/json", json.dumps(data, default=str).encode())
-            elif self.path == "/api/graph":
+            elif path == "/api/graph":
                 data = export_json(store)
                 self._send(200, "application/json", json.dumps(data, default=str).encode())
-            elif self.path == "/api/clusters":
+            elif path == "/api/clusters":
                 data = cluster_view(store)
                 self._send(200, "application/json", json.dumps(data, default=str).encode())
+            elif path == "/api/events":
+                query = parse_qs(parsed.query)
+                try:
+                    limit = int(query.get("limit", ["25"])[0])
+                except ValueError:
+                    limit = 25
+                data = _recent_events(store, limit=limit)
+                self._send(200, "application/json", json.dumps(data, default=str).encode())
+            elif path == "/favicon.ico":
+                self._send(204, "image/x-icon", b"")
             else:
                 self._send(404, "text/plain", b"Not found")
 
@@ -560,25 +1251,10 @@ def run_dashboard(
             self.wfile.write(body)
 
     server = ThreadingHTTPServer((host, port), Handler)
-    logger.info("Flux dashboard running at http://%s:%d", host, port)
-    print(f"Flux Memory dashboard -> http://{host}:{port}")
+    logger.info("Flux dashboard listening on http://%s:%s", host, port)
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         pass
     finally:
         server.server_close()
-
-
-if __name__ == "__main__":
-    import argparse
-    from .storage import FluxStore
-
-    parser = argparse.ArgumentParser(description="Flux Memory Dashboard")
-    parser.add_argument("--db", required=True, help="Path to flux.db")
-    parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=7462)
-    args = parser.parse_args()
-
-    with FluxStore(args.db) as _store:
-        run_dashboard(_store, host=args.host, port=args.port)

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -880,23 +880,18 @@ function isConduitEvent(ev) {
 }
 
 function isGraphRefreshEvent(ev) {
-  return ev.category === 'write'
-    || ev.event === 'grain_stored'
+  return ev.event === 'grain_stored'
     || ev.event === 'entry_point_created'
-    || isConduitEvent(ev);
+    || ev.event === 'bootstrap_conduits_created'
+    || ev.event === 'graph_rebuild_completed';
 }
 
-function scheduleGraphRefreshAfterEvent(ev, color) {
+function scheduleGraphRefreshAfterEvent() {
   if (graphRefreshTimer) clearTimeout(graphRefreshTimer);
   graphRefreshTimer = setTimeout(() => {
     graphRefreshTimer = null;
-    fetchAll().then(() => {
-      if (!isConduitEvent(ev)) return;
-      const now = performance.now();
-      const activated = activateConduitEvent(ev, color, now);
-      if (activated) draw();
-    }).catch(err => console.warn('Graph refresh after event failed', err));
-  }, 250);
+    fetchAll().catch(err => console.warn('Graph refresh after structural event failed', err));
+  }, 1200);
 }
 
 function getPulse(map, key, now) {
@@ -1126,7 +1121,7 @@ function handleFluxEvent(ev) {
   }
 
   if (isGraphRefreshEvent(ev)) {
-    scheduleGraphRefreshAfterEvent(ev, color);
+    scheduleGraphRefreshAfterEvent();
   }
 }
 

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -780,6 +780,7 @@ let hoveredNode = null, hoveredEdge = null;
 let dashOffset = 0;
 let nudgeTimer = null;
 let searchMatchIds = new Set();
+let canvasCssWidth = 0, canvasCssHeight = 0, canvasDpr = 1;
 
 function updateSearchFocus() {
   searchMatchIds = new Set();
@@ -823,7 +824,13 @@ function renderGraph() {
 
   // Set up canvas
   canvas = document.getElementById('graph-canvas');
-  canvas.width = W; canvas.height = H;
+  canvasCssWidth = W;
+  canvasCssHeight = H;
+  canvasDpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 3));
+  canvas.width = Math.max(1, Math.floor(W * canvasDpr));
+  canvas.height = Math.max(1, Math.floor(H * canvasDpr));
+  canvas.style.width = W + 'px';
+  canvas.style.height = H + 'px';
   ctx = canvas.getContext('2d');
 
   // Cancel previous rAF
@@ -886,7 +893,9 @@ function renderGraph() {
 // ── CANVAS DRAW ───────────────────────────────────────────────────────────────
 function draw() {
   if (!ctx || !canvas) return;
-  const W = canvas.width, H = canvas.height;
+  const W = canvasCssWidth || canvas.clientWidth;
+  const H = canvasCssHeight || canvas.clientHeight;
+  ctx.setTransform(canvasDpr, 0, 0, canvasDpr, 0, 0);
   ctx.clearRect(0, 0, W, H);
   ctx.save();
   ctx.translate(transform.x, transform.y);
@@ -1021,7 +1030,8 @@ function draw() {
     // Label
     const label = n.node_type==='entry' ? n.label : n.label.slice(0,22)+(n.label.length>22?'…':'');
     ctx.fillStyle = isSearchMatch ? '#fbbf24' : isSelected ? '#dde3f0' : '#5a6480';
-    ctx.font = `${isSearchMatch ? '600 ' : ''}9px JetBrains Mono, monospace`;
+    ctx.font = `${isSearchMatch ? '600 ' : ''}${window.innerWidth <= 768 ? 10 : 9}px JetBrains Mono, monospace`;
+    ctx.textBaseline = 'middle';
     ctx.fillText(label, n.x + br + 4, n.y + 3.5);
 
     ctx.restore();

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -833,9 +833,14 @@ let activityParticles = [];
 let seenEventKeys = new Set();
 let eventPollTimer = null;
 let lastActivityAt = 0;
+let graphRefreshTimer = null;
 let activityEventEdgeKeys = null;
 
 function activityColor(ev) {
+  if (ev.event === 'conduit_penalized') return '#fb7185';
+  if (ev.event === 'shortcut_created') return '#a78bfa';
+  if (ev.event === 'highway_formed') return '#22d3ee';
+  if (ev.event === 'conduit_reinforced') return '#fbbf24';
   if (ev.category === 'retrieval') return '#22d3ee';
   if (ev.category === 'write') return '#86efac';
   if (ev.category === 'feedback') return ev.data?.useful === false ? '#fb7185' : '#fbbf24';
@@ -844,7 +849,17 @@ function activityColor(ev) {
 }
 
 function eventKey(ev) {
-  return [ev.timestamp, ev.category, ev.event, ev.data?.trace_id, ev.data?.grain_id, ev.data?.feature]
+  return [
+    ev.timestamp,
+    ev.category,
+    ev.event,
+    ev.data?.trace_id,
+    ev.data?.grain_id,
+    ev.data?.feature,
+    ev.data?.conduit_id,
+    ev.data?.from_id,
+    ev.data?.to_id,
+  ]
     .filter(Boolean).join('|');
 }
 
@@ -852,6 +867,36 @@ function edgeKey(l) {
   const sid = typeof l.source === 'object' ? l.source.id : l.source;
   const tid = typeof l.target === 'object' ? l.target.id : l.target;
   return `${sid}->${tid}`;
+}
+
+function isConduitEvent(ev) {
+  const data = ev?.data || {};
+  return [
+    'conduit_reinforced',
+    'conduit_penalized',
+    'highway_formed',
+    'shortcut_created',
+  ].includes(ev?.event) && Boolean(data.conduit_id || (data.from_id && data.to_id));
+}
+
+function isGraphRefreshEvent(ev) {
+  return ev.category === 'write'
+    || ev.event === 'grain_stored'
+    || ev.event === 'entry_point_created'
+    || isConduitEvent(ev);
+}
+
+function scheduleGraphRefreshAfterEvent(ev, color) {
+  if (graphRefreshTimer) clearTimeout(graphRefreshTimer);
+  graphRefreshTimer = setTimeout(() => {
+    graphRefreshTimer = null;
+    fetchAll().then(() => {
+      if (!isConduitEvent(ev)) return;
+      const now = performance.now();
+      const activated = activateConduitEvent(ev, color, now);
+      if (activated) draw();
+    }).catch(err => console.warn('Graph refresh after event failed', err));
+  }, 250);
 }
 
 function getPulse(map, key, now) {
@@ -896,14 +941,16 @@ function pruneActivity(now) {
 }
 
 function activateEdge(edge, color, now) {
+  if (!edge) return 0;
   const key = edgeKey(edge);
-  if (activityEventEdgeKeys?.has(key)) return;
+  if (activityEventEdgeKeys?.has(key)) return 0;
   activityEventEdgeKeys?.add(key);
   activityEdgePulses.set(key, { until: now + 2400, duration: 2400, color });
   activityParticles.push({ key, edge, start: now, duration: 1800, color });
   if (activityParticles.length > 700) {
     activityParticles = activityParticles.slice(-700);
   }
+  return 1;
 }
 
 function pulseNodeOnly(node, color, now) {
@@ -976,14 +1023,38 @@ function activateEventTargets(ev, color, now) {
   return activated;
 }
 
-function findTraceEdge(step) {
+function findConduitEdge(data) {
+  if (!data) return null;
+  const conduitId = data.conduit_id ? String(data.conduit_id) : '';
+  const fromId = data.from_id ? String(data.from_id) : '';
+  const toId = data.to_id ? String(data.to_id) : '';
   return canvasLinks.find(edge => {
     const sid = edge.source?.id;
     const tid = edge.target?.id;
-    if (edge.id && step.conduit_id && edge.id === step.conduit_id) return true;
-    if (sid === step.from_id && tid === step.to_id) return true;
-    return edge.direction === 'bidirectional' && sid === step.to_id && tid === step.from_id;
-  });
+    if (conduitId && edge.id === conduitId) return true;
+    if (fromId && toId && sid === fromId && tid === toId) return true;
+    return Boolean(fromId && toId && edge.direction === 'bidirectional' && sid === toId && tid === fromId);
+  }) || null;
+}
+
+function activateConduitEvent(ev, color, now) {
+  const data = ev.data || {};
+  let activated = 0;
+  activityEventEdgeKeys = new Set();
+  try {
+    const edge = findConduitEdge(data);
+    if (edge) activated += activateEdge(edge, color, now);
+    activated += pulseNodeById(data.from_id, color, now);
+    activated += pulseNodeById(data.to_id, color, now);
+    activated += pulseNodeById(data.grain_id, color, now);
+  } finally {
+    activityEventEdgeKeys = null;
+  }
+  return activated;
+}
+
+function findTraceEdge(step) {
+  return findConduitEdge(step);
 }
 
 async function animateTrace(traceId, color) {
@@ -1042,6 +1113,11 @@ function handleFluxEvent(ev) {
     activated = pulseFeatureNodes(data.feature, color, now);
     setActivityLabel('write/entry_point', color);
     if (activated) draw();
+  } else if (isConduitEvent(ev)) {
+    activated = activateConduitEvent(ev, color, now);
+    const label = ev.category && ev.event ? `${ev.category}/${ev.event}` : 'flux conduit';
+    setActivityLabel(label, color);
+    if (activated) draw();
   } else {
     activated = activateEventTargets(ev, color, now);
     const label = ev.category && ev.event ? `${ev.category}/${ev.event}` : 'flux activity';
@@ -1049,8 +1125,8 @@ function handleFluxEvent(ev) {
     if (activated || ev.category !== 'system') draw();
   }
 
-  if (ev.category === 'write' || ev.event === 'grain_stored' || ev.event === 'entry_point_created') {
-    setTimeout(() => fetchAll().catch(err => console.warn('Graph refresh after event failed', err)), 250);
+  if (isGraphRefreshEvent(ev)) {
+    scheduleGraphRefreshAfterEvent(ev, color);
   }
 }
 

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -316,6 +316,7 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
       background: rgba(15,17,23,0.86); backdrop-filter: blur(14px);
     }
     #search-box { min-width: 152px; max-width: none; flex: 1; border-radius: 10px; }
+    #search-box input { font-size: 16px; line-height: 20px; }
     .filter-group span, .slider-group label { display: none; }
     .filter-btn { padding: 6px 9px; border-radius: 10px; white-space: nowrap; }
     .slider-group { min-width: 112px; }
@@ -460,7 +461,7 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
       <div id="graph-toolbar">
         <div id="search-box">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#5a6480" stroke-width="2.5"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65" stroke-opacity="0.7"></line></svg>
-          <input type="text" id="search-input" placeholder="Search nodes…" oninput="onSearch(this.value)">
+          <input type="text" id="search-input" placeholder="Search nodes…" oninput="onSearch(this.value)" onkeydown="onSearchKey(event)">
         </div>
         <div class="filter-group">
           <span style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.4px">Type</span>
@@ -1312,6 +1313,11 @@ function onSearch(val) {
   searchQuery = val.toLowerCase().trim();
   updateSearchFocus();
   draw();
+}
+function onSearchKey(event) {
+  if (event.key !== 'Enter') return;
+  event.preventDefault();
+  event.currentTarget.blur();
 }
 function onWeightChange(val) {
   weightThreshold = parseFloat(val);

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -149,9 +149,6 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
   }
   .legend-item { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-muted); }
   .legend-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
-  .legend-line { width: 22px; border-radius: 999px; background: var(--cyan); flex-shrink: 0; }
-  .legend-line.weak { height: 1px; opacity: 0.35; }
-  .legend-line.strong { height: 4px; box-shadow: 0 0 10px rgba(34,211,238,0.35); }
   #activity-indicator {
     position: absolute; top: 10px; left: 10px;
     display: flex; align-items: center; gap: 7px;
@@ -167,6 +164,11 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
   }
   #activity-indicator.live .activity-dot {
     background: var(--cyan); box-shadow: 0 0 14px rgba(34,211,238,0.7);
+    animation: activityPulse 900ms ease-out infinite;
+  }
+  @keyframes activityPulse {
+    0% { box-shadow: 0 0 0 0 rgba(34,211,238,0.6); }
+    100% { box-shadow: 0 0 0 8px rgba(34,211,238,0); }
   }
   #tooltip {
     position: fixed; pointer-events: none; z-index: 999;
@@ -520,8 +522,6 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
           <div class="legend-item"><div class="legend-dot" style="background:#e0f2fe"></div>Grain (core)</div>
           <div class="legend-item"><div class="legend-dot" style="background:#a78bfa"></div>Entry</div>
           <div class="legend-item"><div class="legend-dot" style="background:#334155"></div>Dormant</div>
-          <div class="legend-item"><div class="legend-line weak"></div>Weak conduit</div>
-          <div class="legend-item"><div class="legend-line strong"></div>Strong conduit</div>
         </div>
         <div id="no-data-msg" style="display: none;">
           <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.4"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12" stroke-opacity="0.7"></line><line x1="12" y1="16" x2="12.01" y2="16" stroke-opacity="0.7"></line></svg>
@@ -770,25 +770,17 @@ function nodeRadius(n) {
   return 8;
 }
 function clamp01(v) { return Math.max(0, Math.min(1, v)); }
-function edgeWeight(l) {
-  const v = Number(l.effective_weight ?? l.weight ?? 0);
-  return Number.isFinite(v) ? Math.max(0, v) : 0;
-}
-function edgeStrength(l) {
-  return clamp01(l._strength ?? Math.sqrt(Math.min(1, edgeWeight(l))));
-}
 function edgeColor(l) {
-  const s = edgeStrength(l);
-  if (l.direction === 'bidirectional') return d3.interpolateRgb('#2b2544', '#a78bfa')(s);
-  if (l.decay_class === 'core') return d3.interpolateRgb('#1d3a52', '#7dd3fc')(s);
-  if (l.decay_class === 'ephemeral') return d3.interpolateRgb('#17202b', '#0e7490')(s);
-  return d3.interpolateRgb('#1b2634', '#22d3ee')(s);
+  if (l.direction === 'bidirectional') return '#a78bfa';
+  if (l.decay_class === 'core') return '#38bdf8';
+  if (l.decay_class === 'ephemeral') return '#1e3a4a';
+  return '#1e3f5a';
 }
 function edgeWidth(l) {
-  return 0.45 + Math.pow(edgeStrength(l), 1.35) * 4.2;
+  return Math.max(0.5, (l.effective_weight??0.3)*2.5);
 }
 function edgeAlpha(l) {
-  return 0.16 + edgeStrength(l) * 0.64;
+  return 0.55;
 }
 
 function nodePassesFilters(n) {
@@ -842,17 +834,6 @@ let seenEventKeys = new Set();
 let eventPollTimer = null;
 let lastActivityAt = 0;
 let activityEventEdgeKeys = null;
-
-function updateEdgeStrengthScale() {
-  if (!canvasLinks.length) return;
-  const ranked = [...canvasLinks].sort((a, b) => edgeWeight(a) - edgeWeight(b));
-  const denom = Math.max(1, ranked.length - 1);
-  ranked.forEach((edge, index) => {
-    const absolute = Math.sqrt(Math.min(1, edgeWeight(edge)));
-    const rank = index / denom;
-    edge._strength = clamp01((rank * 0.7) + (absolute * 0.3));
-  });
-}
 
 function activityColor(ev) {
   if (ev.category === 'retrieval') return '#22d3ee';
@@ -925,10 +906,15 @@ function activateEdge(edge, color, now) {
   }
 }
 
-function activateNode(node, color, now) {
+function pulseNodeOnly(node, color, now) {
   if (!node) return 0;
   activityNodePulses.set(node.id, { until: now + 3200, duration: 3200, color });
-  let count = 1;
+  return 1;
+}
+
+function activateNode(node, color, now) {
+  let count = pulseNodeOnly(node, color, now);
+  if (!count) return 0;
   for (const edge of canvasLinks) {
     if (edge.source === node || edge.target === node) {
       activateEdge(edge, color, now);
@@ -945,6 +931,13 @@ function activateNodeById(id, color, now) {
   return activateNode(node, color, now);
 }
 
+function pulseNodeById(id, color, now) {
+  if (!id) return 0;
+  const needle = String(id);
+  const node = canvasNodes.find(n => n.id === needle || n.feature === needle || n.label === needle);
+  return pulseNodeOnly(node, color, now);
+}
+
 function activateFeature(feature, color, now) {
   if (!feature) return 0;
   const needle = String(feature).toLowerCase();
@@ -956,29 +949,108 @@ function activateFeature(feature, color, now) {
   return count;
 }
 
-function handleFluxEvent(ev) {
-  const now = performance.now();
-  const color = activityColor(ev);
+function pulseFeatureNodes(feature, color, now) {
+  if (!feature) return 0;
+  const needle = String(feature).toLowerCase();
+  let count = 0;
+  for (const node of canvasNodes) {
+    const haystack = [node.feature, node.label, node.id, node.provenance].filter(Boolean).join(' ').toLowerCase();
+    if (haystack.includes(needle)) count += pulseNodeOnly(node, color, now);
+  }
+  return count;
+}
+
+function activateEventTargets(ev, color, now) {
   const data = ev.data || {};
   let activated = 0;
   activityEventEdgeKeys = new Set();
-
   try {
     activated += activateNodeById(data.grain_id, color, now);
     if (Array.isArray(data.features)) {
       for (const feature of data.features.slice(0, 12)) activated += activateFeature(feature, color, now);
     }
     activated += activateFeature(data.feature, color, now);
+  } finally {
+    activityEventEdgeKeys = null;
+  }
+  return activated;
+}
 
-    if (ev.category === 'write' || ev.event === 'grain_stored' || ev.event === 'entry_point_created') {
-      setTimeout(() => fetchAll().catch(err => console.warn('Graph refresh after event failed', err)), 250);
-    }
+function findTraceEdge(step) {
+  return canvasLinks.find(edge => {
+    const sid = edge.source?.id;
+    const tid = edge.target?.id;
+    if (edge.id && step.conduit_id && edge.id === step.conduit_id) return true;
+    if (sid === step.from_id && tid === step.to_id) return true;
+    return edge.direction === 'bidirectional' && sid === step.to_id && tid === step.from_id;
+  });
+}
 
+async function animateTrace(traceId, color) {
+  if (!traceId) return 0;
+  const payload = await fetchJSON(`/api/trace?trace_id=${encodeURIComponent(traceId)}`);
+  const steps = (payload.steps || [])
+    .filter(step => step.from_id && step.to_id)
+    .sort((a, b) => (a.hop ?? 0) - (b.hop ?? 0) || Math.abs(b.signal ?? 0) - Math.abs(a.signal ?? 0))
+    .slice(0, 300);
+
+  const seenEdges = new Set();
+  steps.forEach((step, index) => {
+    const delay = Math.min(step.hop ?? 0, 6) * 320 + Math.min(index, 90) * 10;
+    setTimeout(() => {
+      const edge = findTraceEdge(step);
+      const now = performance.now();
+      pulseNodeById(step.from_id, color, now);
+      pulseNodeById(step.to_id, color, now);
+      if (edge) {
+        const key = edgeKey(edge);
+        if (!seenEdges.has(key)) {
+          seenEdges.add(key);
+          activateEdge(edge, color, now);
+        }
+      }
+      draw();
+    }, delay);
+  });
+  return steps.length;
+}
+
+function handleFluxEvent(ev) {
+  const now = performance.now();
+  const color = activityColor(ev);
+  const data = ev.data || {};
+  let activated = 0;
+  const traceId = data.trace_id || ev.trace_id;
+
+  if (ev.category === 'retrieval' && ev.event === 'grains_returned' && traceId) {
+    setActivityLabel(`trace/${String(traceId).slice(0, 8)}`, color);
+    animateTrace(traceId, color).then(count => {
+      if (!count) {
+        const fallbackNow = performance.now();
+        const fallback = activateEventTargets(ev, color, fallbackNow);
+        if (fallback) draw();
+      }
+    }).catch(err => {
+      console.warn('Trace animation failed', err);
+      const fallbackNow = performance.now();
+      const fallback = activateEventTargets(ev, color, fallbackNow);
+      if (fallback) draw();
+    });
+  } else if (ev.category === 'retrieval' && ev.event === 'features_extracted') {
+    setActivityLabel('retrieval/features', color);
+  } else if (ev.event === 'entry_point_created') {
+    activated = pulseFeatureNodes(data.feature, color, now);
+    setActivityLabel('write/entry_point', color);
+    if (activated) draw();
+  } else {
+    activated = activateEventTargets(ev, color, now);
     const label = ev.category && ev.event ? `${ev.category}/${ev.event}` : 'flux activity';
     setActivityLabel(label, color);
     if (activated || ev.category !== 'system') draw();
-  } finally {
-    activityEventEdgeKeys = null;
+  }
+
+  if (ev.category === 'write' || ev.event === 'grain_stored' || ev.event === 'entry_point_created') {
+    setTimeout(() => fetchAll().catch(err => console.warn('Graph refresh after event failed', err)), 250);
   }
 }
 
@@ -1076,7 +1148,6 @@ function renderGraph() {
     source: nodeMap.get(typeof l.source==='object'?l.source.id:l.source) || (typeof l.source==='object'?l.source.id:l.source),
     target: nodeMap.get(typeof l.target==='object'?l.target.id:l.target) || (typeof l.target==='object'?l.target.id:l.target),
   })).filter(l => l.source && l.target && typeof l.source==='object' && typeof l.target==='object');
-  updateEdgeStrengthScale();
 
   // Set up canvas
   canvas = document.getElementById('graph-canvas');
@@ -1494,7 +1565,6 @@ function showEdgeTooltip(event, d) {
   showTooltip(event.clientX, event.clientY, `${sid.slice(0,10)}… → ${tid.slice(0,10)}…`, [
     ['weight', (d.weight??0).toFixed(4)],
     ['eff. weight', (d.effective_weight??0).toFixed(4)],
-    ['visual strength', Math.round(edgeStrength(d) * 100) + '%'],
     ['direction', d.direction],
     ['decay', d.decay_class??'—'],
     ['use count', d.use_count??0],
@@ -1820,6 +1890,25 @@ def _recent_events(store: Any, limit: int = 25) -> dict[str, list[dict[str, Any]
     return {"events": events}
 
 
+def _trace_details(store: Any, trace_id: str) -> dict[str, Any]:
+    if not trace_id:
+        return {"trace_id": "", "steps": []}
+    trace = store.get_trace(trace_id)
+    if trace is None:
+        return {"trace_id": trace_id, "steps": []}
+    try:
+        steps = json.loads(trace.trace_data or "[]")
+    except json.JSONDecodeError:
+        steps = []
+    return {
+        "trace_id": trace.id,
+        "query": trace.query_text,
+        "hop_count": trace.hop_count,
+        "activated_grain_count": trace.activated_grain_count,
+        "steps": steps if isinstance(steps, list) else [],
+    }
+
+
 def run_dashboard(
     store: Any,
     host: str = "127.0.0.1",
@@ -1849,6 +1938,11 @@ def run_dashboard(
                 self._send(200, "application/json", json.dumps(data, default=str).encode())
             elif path == "/api/clusters":
                 data = cluster_view(store)
+                self._send(200, "application/json", json.dumps(data, default=str).encode())
+            elif path == "/api/trace":
+                query = parse_qs(parsed.query)
+                trace_id = query.get("trace_id", [""])[0]
+                data = _trace_details(store, trace_id=trace_id)
                 self._send(200, "application/json", json.dumps(data, default=str).encode())
             elif path == "/api/events":
                 query = parse_qs(parsed.query)

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -29,148 +29,473 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Flux Memory Dashboard</title>
 <style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: system-ui, sans-serif; background: #0f1117; color: #e2e8f0; }
-  header { background: #1e2330; padding: 16px 24px; border-bottom: 1px solid #2d3748; }
-  header h1 { font-size: 1.25rem; font-weight: 600; }
-  header span { font-size: 0.8rem; color: #718096; margin-left: 12px; }
-  main { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 20px; }
-  .card { background: #1e2330; border: 1px solid #2d3748; border-radius: 8px; padding: 16px; }
-  .card h2 { font-size: 0.9rem; font-weight: 600; text-transform: uppercase;
-              letter-spacing: 0.05em; color: #718096; margin-bottom: 12px; }
-  .status-badge { display: inline-block; padding: 4px 12px; border-radius: 999px;
-                  font-size: 0.85rem; font-weight: 600; }
-  .healthy { background: #22543d; color: #9ae6b4; }
-  .warning { background: #744210; color: #fbd38d; }
-  .critical { background: #742a2a; color: #feb2b2; }
-  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
-  th { text-align: left; color: #718096; padding: 4px 8px; border-bottom: 1px solid #2d3748; }
-  td { padding: 6px 8px; border-bottom: 1px solid #1a202c; }
-  .ok { color: #68d391; }
-  .bad { color: #fc8181; }
-  #graph-canvas { width: 100%; height: 300px; background: #0f1117;
-                  border-radius: 4px; overflow: hidden; position: relative; }
-  #graph-canvas svg { width: 100%; height: 100%; }
-  .warn-item { padding: 8px; background: #2d3748; border-radius: 4px;
-               margin-bottom: 6px; font-size: 0.82rem; }
-  .warn-item .sig { font-weight: 600; color: #fbd38d; }
-  .refresh { font-size: 0.75rem; color: #4a5568; margin-top: 8px; }
-  .stat { display: flex; justify-content: space-between; padding: 4px 0;
-          font-size: 0.85rem; border-bottom: 1px solid #1a202c; }
+  :root {
+    --bg: #0b0d12;
+    --surface: #151a22;
+    --surface-2: #1b2230;
+    --line: #2a3445;
+    --muted: #8a94a7;
+    --text: #edf2f7;
+    --teal: #2dd4bf;
+    --green: #74d99f;
+    --amber: #f2b84b;
+    --rose: #fb7185;
+    --violet: #a78bfa;
+    --blue: #60a5fa;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-width: 320px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 24px;
+    background: #11161f;
+    border-bottom: 1px solid var(--line);
+  }
+  .brand { display: flex; align-items: center; gap: 12px; }
+  .brand-mark {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    background: #1f2a38;
+    color: var(--amber);
+    font-weight: 800;
+  }
+  h1 { margin: 0; font-size: 1.05rem; font-weight: 700; letter-spacing: 0; }
+  .updated { color: var(--muted); font-size: 0.82rem; margin-top: 2px; }
+  .header-actions { display: flex; align-items: center; gap: 10px; }
+  button {
+    border: 1px solid var(--line);
+    background: #19212c;
+    color: var(--text);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font: inherit;
+    cursor: pointer;
+  }
+  button:hover { border-color: #3b4a60; background: #202a38; }
+  main { padding: 18px; display: grid; gap: 16px; }
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 12px;
+  }
+  .metric, .panel {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+  }
+  .metric { padding: 14px; min-height: 96px; }
+  .metric .label {
+    color: var(--muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .metric .value { font-size: 1.7rem; line-height: 1.2; font-weight: 750; margin-top: 8px; }
+  .metric .sub { color: var(--muted); font-size: 0.78rem; margin-top: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .value.good { color: var(--green); }
+  .value.warn { color: var(--amber); }
+  .value.bad { color: var(--rose); }
+  .value.info { color: var(--teal); }
+  .grid {
+    display: grid;
+    grid-template-columns: minmax(360px, 0.92fr) minmax(420px, 1.08fr);
+    gap: 16px;
+  }
+  .panel { overflow: hidden; }
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--line);
+    background: #171d27;
+  }
+  .panel h2 {
+    margin: 0;
+    font-size: 0.82rem;
+    font-weight: 750;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #b4bed0;
+  }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 9px;
+    border-radius: 999px;
+    font-size: 0.77rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+  .badge.healthy { background: rgba(116, 217, 159, 0.14); color: var(--green); }
+  .badge.warning { background: rgba(242, 184, 75, 0.16); color: var(--amber); }
+  .badge.critical { background: rgba(251, 113, 133, 0.16); color: var(--rose); }
+  .panel-body { padding: 14px 16px; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.84rem; }
+  th {
+    text-align: left;
+    color: var(--muted);
+    padding: 0 8px 8px;
+    border-bottom: 1px solid var(--line);
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  td { padding: 9px 8px; border-bottom: 1px solid rgba(42, 52, 69, 0.52); }
+  tr:last-child td { border-bottom: 0; }
+  .signal-name { color: #dce6f6; }
+  .signal-value { color: #cbd5e1; font-variant-numeric: tabular-nums; }
+  .state-dot {
+    display: inline-block;
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    background: var(--rose);
+  }
+  .state-dot.ok { background: var(--green); }
+  .warnings { display: grid; gap: 10px; }
+  .warn-item {
+    border: 1px solid rgba(242, 184, 75, 0.22);
+    background: rgba(242, 184, 75, 0.08);
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
+  .warn-title { color: var(--amber); font-size: 0.82rem; font-weight: 800; margin-bottom: 4px; }
+  .warn-text { color: #d7dee9; font-size: 0.84rem; line-height: 1.4; }
+  .muted { color: var(--muted); }
+  .graph-panel { min-height: 500px; }
+  .graph-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+  .pill {
+    border: 1px solid var(--line);
+    background: #121821;
+    color: #b8c2d4;
+    border-radius: 999px;
+    padding: 5px 8px;
+  }
+  #graph-canvas {
+    position: relative;
+    height: 430px;
+    background: #080b10;
+    border-top: 1px solid #101722;
+  }
+  #graph-svg { width: 100%; height: 100%; display: block; }
+  .empty-note {
+    position: absolute;
+    left: 18px;
+    bottom: 16px;
+    max-width: min(520px, calc(100% - 36px));
+    color: #aab5c7;
+    font-size: 0.86rem;
+    background: rgba(21, 26, 34, 0.88);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 10px 12px;
+  }
+  .legend {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    color: var(--muted);
+    font-size: 0.78rem;
+  }
+  .legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .swatch { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
+  .span-2 { grid-column: 1 / -1; }
+  @media (max-width: 1100px) {
+    .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 680px) {
+    header { align-items: flex-start; flex-direction: column; padding: 16px; }
+    main { padding: 12px; }
+    .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .metric .value { font-size: 1.35rem; }
+    #graph-canvas { height: 340px; }
+  }
 </style>
 </head>
 <body>
 <header>
-  <h1>⚡ Flux Memory</h1>
-  <span id="computed-at">Loading…</span>
+  <div class="brand">
+    <div class="brand-mark">F</div>
+    <div>
+      <h1>Flux Memory</h1>
+      <div class="updated" id="computed-at">Loading</div>
+    </div>
+  </div>
+  <div class="header-actions">
+    <div id="status-badge" class="badge warning">Loading</div>
+    <button id="refresh-button" type="button" title="Refresh dashboard">Refresh</button>
+  </div>
 </header>
 <main>
+  <section class="metrics" id="metrics"></section>
 
-<div class="card">
-  <h2>Health Status</h2>
-  <div id="status-badge" class="status-badge" style="margin-bottom:12px">…</div>
-  <table>
-    <thead><tr><th>Signal</th><th>Value</th><th>OK?</th></tr></thead>
-    <tbody id="signals-table"></tbody>
-  </table>
-</div>
+  <section class="grid">
+    <div class="panel">
+      <div class="panel-header">
+        <h2>Health Signals</h2>
+      </div>
+      <div class="panel-body">
+        <table>
+          <thead><tr><th>Signal</th><th>Value</th><th>State</th></tr></thead>
+          <tbody id="signals-table"></tbody>
+        </table>
+      </div>
+    </div>
 
-<div class="card">
-  <h2>Active Warnings</h2>
-  <div id="warnings-list"><em style="color:#4a5568">None</em></div>
-</div>
+    <div class="panel">
+      <div class="panel-header">
+        <h2>Warnings</h2>
+        <span class="pill" id="warning-count">0 active</span>
+      </div>
+      <div class="panel-body">
+        <div id="warnings-list" class="warnings"><span class="muted">None</span></div>
+      </div>
+    </div>
+  </section>
 
-<div class="card" style="grid-column:1/-1">
-  <h2>Graph Overview</h2>
-  <div id="graph-canvas"><svg id="graph-svg"></svg></div>
-  <p class="refresh" id="graph-stats"></p>
-</div>
-
+  <section class="panel graph-panel span-2">
+    <div class="panel-header">
+      <div>
+        <h2>Graph Overview</h2>
+        <div class="graph-meta" id="graph-stats"></div>
+      </div>
+      <div class="legend">
+        <span><i class="swatch" style="background:var(--teal)"></i>Entry</span>
+        <span><i class="swatch" style="background:var(--blue)"></i>Grain</span>
+        <span><i class="swatch" style="background:var(--amber)"></i>Core</span>
+        <span><i class="swatch" style="background:var(--green)"></i>Strong conduit</span>
+      </div>
+    </div>
+    <div id="graph-canvas">
+      <svg id="graph-svg"></svg>
+      <div id="empty-note" class="empty-note" hidden></div>
+    </div>
+  </section>
 </main>
-<p class="refresh" style="padding:0 20px 16px">Auto-refreshes every 30s.</p>
 <script>
+const fmt = new Intl.NumberFormat();
+
+function safeNumber(value, digits = 3) {
+  const n = Number(value || 0);
+  return Number.isInteger(n) ? fmt.format(n) : n.toFixed(digits);
+}
+
+function metricCard(label, value, sub, tone) {
+  const el = document.createElement('div');
+  el.className = 'metric';
+  el.innerHTML = `<div class="label"></div><div class="value ${tone || ''}"></div><div class="sub"></div>`;
+  el.children[0].textContent = label;
+  el.children[1].textContent = value;
+  el.children[2].textContent = sub || '';
+  return el;
+}
+
 async function fetchJSON(url) {
-  const r = await fetch(url);
+  const r = await fetch(url, { cache: 'no-store' });
+  if (!r.ok) throw new Error(`${url} returned ${r.status}`);
   return r.json();
+}
+
+function renderMetrics(health, graph) {
+  const stats = graph.stats || {};
+  const sig = health.signals || {};
+  const metrics = document.getElementById('metrics');
+  metrics.innerHTML = '';
+  metrics.appendChild(metricCard('Grains', safeNumber(stats.grains), `${safeNumber(stats.active_grains)} active`, 'info'));
+  metrics.appendChild(metricCard('Entries', safeNumber(stats.entries), 'feature anchors', ''));
+  metrics.appendChild(metricCard('Conduits', safeNumber(stats.conduits), `${safeNumber(sig.avg_conduit_weight?.value)} avg weight`, stats.conduits > 0 ? 'good' : 'warn'));
+  metrics.appendChild(metricCard('Embeddings', safeNumber(stats.embeddings), 'vector fallback index', stats.embeddings > 0 ? 'good' : 'warn'));
+  metrics.appendChild(metricCard('Retrieval', `${safeNumber((sig.retrieval_success_rate?.value || 0) * 100, 1)}%`, 'success rate', ''));
+  metrics.appendChild(metricCard('Fallback', `${safeNumber((sig.fallback_trigger_rate?.value || 0) * 100, 1)}%`, 'trigger rate', (sig.fallback_trigger_rate?.value || 0) > 0.2 ? 'bad' : 'good'));
 }
 
 function renderHealth(data) {
   document.getElementById('computed-at').textContent =
-    'Last computed: ' + (data.computed_at || '?');
+    `Last computed ${data.computed_at || 'unknown'}`;
 
   const badge = document.getElementById('status-badge');
-  badge.textContent = (data.status || 'unknown').toUpperCase();
-  badge.className = 'status-badge ' + (data.status || 'unknown');
+  const status = data.status || 'unknown';
+  badge.textContent = status;
+  badge.className = `badge ${status}`;
 
   const tbody = document.getElementById('signals-table');
   tbody.innerHTML = '';
   for (const [name, sig] of Object.entries(data.signals || {})) {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${name}</td><td>${(+sig.value).toFixed(3)}</td>
-      <td class="${sig.healthy ? 'ok' : 'bad'}">${sig.healthy ? '✓' : '✗'}</td>`;
+    const nameCell = document.createElement('td');
+    const valueCell = document.createElement('td');
+    const stateCell = document.createElement('td');
+    nameCell.className = 'signal-name';
+    valueCell.className = 'signal-value';
+    nameCell.textContent = name;
+    valueCell.textContent = safeNumber(sig.value);
+    const dot = document.createElement('span');
+    dot.className = `state-dot ${sig.healthy ? 'ok' : ''}`;
+    dot.title = sig.healthy ? 'healthy' : 'warning';
+    stateCell.appendChild(dot);
+    tr.append(nameCell, valueCell, stateCell);
     tbody.appendChild(tr);
   }
 
   const wlist = document.getElementById('warnings-list');
+  const count = document.getElementById('warning-count');
   const warns = data.active_warnings || [];
+  count.textContent = `${warns.length} active`;
+  wlist.innerHTML = '';
   if (warns.length === 0) {
-    wlist.innerHTML = '<em style="color:#4a5568">None</em>';
-  } else {
-    wlist.innerHTML = warns.map(w =>
-      `<div class="warn-item"><span class="sig">${w.signal}</span>: ${w.suggestion}</div>`
-    ).join('');
+    const empty = document.createElement('span');
+    empty.className = 'muted';
+    empty.textContent = 'None';
+    wlist.appendChild(empty);
+    return;
   }
+  warns.forEach(w => {
+    const item = document.createElement('div');
+    item.className = 'warn-item';
+    const title = document.createElement('div');
+    title.className = 'warn-title';
+    title.textContent = w.signal || 'warning';
+    const text = document.createElement('div');
+    text.className = 'warn-text';
+    text.textContent = w.suggestion || '';
+    item.append(title, text);
+    wlist.appendChild(item);
+  });
 }
 
 function renderGraph(data) {
   const nodes = data.nodes || [];
   const links = data.links || [];
-  const stats = document.getElementById('graph-stats');
-  stats.textContent = `${nodes.length} nodes · ${links.length} edges`;
+  const stats = data.stats || {};
+  const graphStats = document.getElementById('graph-stats');
+  graphStats.innerHTML = '';
+  [
+    `${safeNumber(stats.grains || 0)} grains`,
+    `${safeNumber(stats.entries || 0)} entries`,
+    `${safeNumber(stats.conduits || 0)} conduits`,
+    `${safeNumber(stats.embeddings || 0)} embeddings`
+  ].forEach(text => {
+    const pill = document.createElement('span');
+    pill.className = 'pill';
+    pill.textContent = text;
+    graphStats.appendChild(pill);
+  });
 
   const svg = document.getElementById('graph-svg');
-  const W = svg.clientWidth || 800, H = svg.clientHeight || 300;
+  const note = document.getElementById('empty-note');
+  const W = Math.max(svg.clientWidth || 960, 480);
+  const H = Math.max(svg.clientHeight || 430, 300);
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
   svg.innerHTML = '';
+  note.hidden = true;
 
   if (nodes.length === 0) {
-    svg.innerHTML = '<text x="50%" y="50%" text-anchor="middle" fill="#4a5568">No data</text>';
+    note.hidden = false;
+    note.textContent = 'No graph data is stored yet.';
     return;
   }
 
-  // Minimal force-free layout: place nodes in a circle.
-  const pos = {};
-  nodes.forEach((n, i) => {
-    const angle = (2 * Math.PI * i) / nodes.length;
-    pos[n.id] = { x: W/2 + (W*0.38)*Math.cos(angle), y: H/2 + (H*0.38)*Math.sin(angle) };
+  const degree = {};
+  links.forEach(l => {
+    degree[l.source] = (degree[l.source] || 0) + 1;
+    degree[l.target] = (degree[l.target] || 0) + 1;
   });
 
-  // Edges first.
+  const entries = nodes.filter(n => n.node_type === 'entry');
+  const grains = nodes.filter(n => n.node_type !== 'entry');
+  const pos = {};
+
+  if (links.length === 0) {
+    note.hidden = false;
+    note.textContent = 'No conduits are stored, so grains are currently isolated.';
+    layoutBand(entries, W * 0.22, W * 0.14, H, pos);
+    layoutBand(grains, W * 0.67, W * 0.26, H, pos);
+  } else {
+    layoutLinked(nodes, links, degree, W, H, pos);
+  }
+
   links.forEach(l => {
     const s = pos[l.source], t = pos[l.target];
     if (!s || !t) return;
-    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-    const w = Math.max(0.5, (l.effective_weight || 0.3) * 4);
-    const hue = l.effective_weight > 0.5 ? '#68d391' : l.effective_weight > 0.25 ? '#fbd38d' : '#fc8181';
-    line.setAttribute('x1', s.x); line.setAttribute('y1', s.y);
-    line.setAttribute('x2', t.x); line.setAttribute('y2', t.y);
-    line.setAttribute('stroke', hue); line.setAttribute('stroke-width', w);
-    line.setAttribute('opacity', '0.6');
-    svg.appendChild(line);
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const midX = (s.x + t.x) / 2;
+    const midY = (s.y + t.y) / 2 - 18;
+    const w = Math.max(0.8, (l.effective_weight || 0.3) * 5);
+    const color = l.effective_weight > 0.5 ? 'var(--green)' : l.effective_weight > 0.25 ? 'var(--amber)' : 'var(--rose)';
+    path.setAttribute('d', `M ${s.x} ${s.y} Q ${midX} ${midY} ${t.x} ${t.y}`);
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', color);
+    path.setAttribute('stroke-width', w);
+    path.setAttribute('opacity', '0.58');
+    svg.appendChild(path);
   });
 
-  // Nodes.
   nodes.forEach(n => {
     const p = pos[n.id];
     if (!p) return;
     const isEntry = n.node_type === 'entry';
-    const fill = isEntry ? '#4299e1' : (n.decay_class === 'core' ? '#d69e2e' : '#718096');
-    const r = isEntry ? 6 : 5;
+    const isCore = n.decay_class === 'core';
+    const r = Math.min(12, 4.5 + Math.sqrt(degree[n.id] || 0) * 1.5 + (isEntry ? 1 : 0));
     const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-    circle.setAttribute('cx', p.x); circle.setAttribute('cy', p.y);
-    circle.setAttribute('r', r); circle.setAttribute('fill', fill);
-    circle.setAttribute('opacity', n.status === 'dormant' ? '0.3' : '0.85');
-    circle.innerHTML = `<title>${n.label}</title>`;
+    circle.setAttribute('cx', p.x);
+    circle.setAttribute('cy', p.y);
+    circle.setAttribute('r', r);
+    circle.setAttribute('fill', isEntry ? 'var(--teal)' : isCore ? 'var(--amber)' : 'var(--blue)');
+    circle.setAttribute('stroke', '#0b0d12');
+    circle.setAttribute('stroke-width', '1.5');
+    circle.setAttribute('opacity', n.status === 'dormant' ? '0.34' : '0.88');
+    const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+    title.textContent = n.label || n.id;
+    circle.appendChild(title);
     svg.appendChild(circle);
+  });
+}
+
+function layoutBand(items, centerX, radiusX, height, pos) {
+  const rows = Math.max(1, Math.ceil(Math.sqrt(items.length || 1)));
+  items.forEach((n, i) => {
+    const row = i % rows;
+    const col = Math.floor(i / rows);
+    const x = centerX + ((col % 6) - 2.5) * Math.max(18, radiusX / 4);
+    const y = 54 + row * ((height - 108) / Math.max(rows - 1, 1));
+    pos[n.id] = { x, y };
+  });
+}
+
+function layoutLinked(nodes, links, degree, W, H, pos) {
+  const sorted = [...nodes].sort((a, b) => (degree[b.id] || 0) - (degree[a.id] || 0));
+  sorted.forEach((n, i) => {
+    const ring = i < 10 ? 0 : i < 40 ? 1 : 2;
+    const ringIndex = ring === 0 ? i : ring === 1 ? i - 10 : i - 40;
+    const ringCount = ring === 0 ? Math.min(10, sorted.length) : ring === 1 ? Math.min(30, sorted.length - 10) : Math.max(1, sorted.length - 40);
+    const angle = (2 * Math.PI * ringIndex) / Math.max(ringCount, 1) + ring * 0.26;
+    const rx = W * (0.16 + ring * 0.13);
+    const ry = H * (0.15 + ring * 0.12);
+    pos[n.id] = { x: W / 2 + rx * Math.cos(angle), y: H / 2 + ry * Math.sin(angle) };
   });
 }
 
@@ -180,6 +505,7 @@ async function refresh() {
       fetchJSON('/api/health'),
       fetchJSON('/api/graph'),
     ]);
+    renderMetrics(health, graph);
     renderHealth(health);
     renderGraph(graph);
   } catch (e) {
@@ -187,8 +513,9 @@ async function refresh() {
   }
 }
 
+document.getElementById('refresh-button').addEventListener('click', refresh);
 refresh();
-setInterval(refresh, 30000);
+setInterval(refresh, 15000);
 </script>
 </body>
 </html>

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -141,7 +141,7 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
   #weight-slider { width: 80px; accent-color: var(--cyan); cursor: pointer; }
   #weight-val { font-size: 11px; font-family: var(--font-mono); color: var(--cyan); min-width: 28px; }
   #graph-container { flex: 1; position: relative; overflow: hidden; }
-  #graph-canvas { width: 100%; height: 100%; display: block; cursor: grab; }
+  #graph-canvas { width: 100%; height: 100%; display: block; cursor: grab; touch-action: none; }
   #graph-canvas.dragging { cursor: grabbing; }
   #graph-overlay {
     position: absolute; bottom: 12px; left: 12px;
@@ -272,11 +272,117 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
   @keyframes spin { to { transform: rotate(360deg); } }
   #loading .load-text { font-size: 12px; color: var(--text-muted); font-family: var(--font-mono); }
 
+  #mobile-bubble-bar,
+  #mobile-sheet-close { display: none; }
+
   /* RESPONSIVE */
   @media (max-width: 768px) {
-    #main { flex-direction: column; }
-    #right-panel { width: 100%; height: 300px; border-top: 1px solid var(--border); }
-    #graph-panel { border-right: none; }
+    html, body { overflow: hidden; }
+    #app { height: 100svh; }
+    #topbar {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 30;
+      padding: calc(8px + env(safe-area-inset-top, 0px)) 10px 8px;
+      gap: 8px; background: rgba(8,10,14,0.92); backdrop-filter: blur(16px);
+      border-bottom: 1px solid rgba(37,44,58,0.75);
+    }
+    #topbar .brand svg { width: 20px; height: 20px; }
+    #topbar .brand-name { font-size: 13px; }
+    #topbar .brand-sub, #computed-at, #refresh-interval, .divider { display: none; }
+    #status-badge { padding: 3px 8px; font-size: 10px; }
+    #metrics-strip {
+      order: 3; width: 100%; flex: none;
+      display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 4px;
+    }
+    .metric-pill { min-width: 0; padding: 4px 7px; border-radius: 8px; }
+    .metric-pill .m-label { font-size: 8px; letter-spacing: 0.35px; }
+    .metric-pill .m-value { font-size: 14px; }
+    .metric-pill:nth-child(n+5) { display: none; }
+    #topbar-controls { margin-left: auto; }
+    .icon-btn { width: 32px; height: 32px; border-radius: 10px; }
+
+    #main { height: 100svh; padding-top: 86px; flex-direction: column; }
+    #graph-panel { border-right: none; min-height: 0; height: 100%; }
+    #graph-toolbar {
+      position: fixed; top: calc(86px + env(safe-area-inset-top, 0px)); left: 8px; right: 8px; z-index: 25;
+      padding: 6px; gap: 6px; flex-wrap: nowrap; overflow-x: auto;
+      border: 1px solid rgba(37,44,58,0.9); border-radius: 14px;
+      background: rgba(15,17,23,0.86); backdrop-filter: blur(14px);
+    }
+    #search-box { min-width: 152px; max-width: none; flex: 1; border-radius: 10px; }
+    .filter-group span, .slider-group label { display: none; }
+    .filter-btn { padding: 6px 9px; border-radius: 10px; white-space: nowrap; }
+    .slider-group { min-width: 112px; }
+    #weight-slider { width: 70px; }
+    #graph-container { height: calc(100svh - 86px); }
+    #graph-canvas { height: 100%; }
+    #graph-overlay { display: none; }
+    #graph-stats {
+      top: auto; right: auto; left: 10px;
+      bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+      border-radius: 10px; background: rgba(8,10,14,0.72);
+    }
+    #tooltip { display: none; }
+
+    #right-panel {
+      position: fixed; left: 10px; right: 10px;
+      bottom: calc(10px + env(safe-area-inset-bottom, 0px)); z-index: 45;
+      width: auto; height: min(64svh, 520px); max-height: 64svh;
+      border: 1px solid rgba(37,44,58,0.95); border-radius: 18px;
+      background: rgba(15,17,23,0.96); box-shadow: 0 22px 70px rgba(0,0,0,0.7);
+      transform: translateY(calc(100% + 20px)); transition: transform 180ms ease;
+      overflow-y: auto; backdrop-filter: blur(18px);
+    }
+    body.mobile-sheet-open #right-panel { transform: translateY(0); }
+    #mobile-sheet-close {
+      display: flex; position: sticky; top: 0; z-index: 3;
+      width: 100%; height: 38px; align-items: center; justify-content: center;
+      background: rgba(15,17,23,0.98); border: 0; border-bottom: 1px solid var(--border);
+      color: var(--text-muted);
+    }
+    #mobile-sheet-close::before {
+      content: ''; width: 46px; height: 4px; border-radius: 4px; background: var(--border2);
+    }
+    #mobile-bubble-bar {
+      display: flex; position: fixed; z-index: 40; left: 50%;
+      bottom: calc(12px + env(safe-area-inset-bottom, 0px)); transform: translateX(-50%);
+      gap: 8px; padding: 8px; border-radius: 999px;
+      background: rgba(15,17,23,0.88); border: 1px solid rgba(37,44,58,0.9);
+      box-shadow: 0 16px 45px rgba(0,0,0,0.55); backdrop-filter: blur(18px);
+      transition: opacity 150ms ease, transform 150ms ease;
+    }
+    body.mobile-sheet-open #mobile-bubble-bar {
+      opacity: 0; pointer-events: none; transform: translateX(-50%) translateY(12px);
+    }
+    .mobile-bubble {
+      width: 42px; height: 42px; display: flex; align-items: center; justify-content: center;
+      border-radius: 999px; border: 1px solid var(--border);
+      background: var(--surface2); color: var(--text-muted);
+    }
+    .mobile-bubble.active {
+      color: var(--cyan); border-color: rgba(34,211,238,0.38);
+      background: var(--cyan-dim); box-shadow: 0 0 22px rgba(34,211,238,0.14);
+    }
+    .mobile-bubble.warn.active {
+      color: var(--amber); border-color: rgba(251,191,36,0.38);
+      background: var(--amber-dim); box-shadow: 0 0 22px rgba(251,191,36,0.12);
+    }
+  }
+
+  @media (max-width: 430px) and (max-height: 260px) {
+    #topbar { padding: 6px 8px; gap: 6px; }
+    #topbar .brand-name { font-size: 11px; }
+    #status-badge { font-size: 9px; padding: 2px 6px; }
+    #metrics-strip {
+      display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 3px;
+    }
+    .metric-pill { padding: 2px 5px; }
+    .metric-pill .m-label { font-size: 7px; }
+    .metric-pill .m-value { font-size: 11px; }
+    .metric-pill:nth-child(n+4), #topbar-controls, #graph-toolbar,
+    #graph-overlay, #right-panel, #mobile-bubble-bar { display: none; }
+    #main { padding-top: 44px; }
+    #graph-container { height: calc(100svh - 44px); }
+    #graph-stats { bottom: 6px; left: 6px; font-size: 8px; padding: 3px 6px; }
   }
 </style>
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -392,6 +498,7 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
 
     <!-- RIGHT PANEL -->
     <div id="right-panel">
+      <button id="mobile-sheet-close" onclick="closeMobileSheet()" aria-label="Close panel"></button>
 
       <!-- INSPECTOR -->
       <div class="rpanel-section">
@@ -441,6 +548,21 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
       </div>
 
     </div>
+  </div>
+
+  <div id="mobile-bubble-bar" aria-label="Mobile dashboard panels">
+    <button class="mobile-bubble active" id="mobile-bubble-inspector" title="Inspector" onclick="openMobileSheet('inspector')" aria-label="Inspector">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+    </button>
+    <button class="mobile-bubble warn" id="mobile-bubble-warnings" title="Warnings" onclick="openMobileSheet('warnings')" aria-label="Warnings">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+    </button>
+    <button class="mobile-bubble" id="mobile-bubble-health" title="Health" onclick="openMobileSheet('health')" aria-label="Health">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+    </button>
+    <button class="mobile-bubble" title="Refresh" onclick="fetchAll()" aria-label="Refresh">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
+    </button>
   </div>
 </div>
 
@@ -712,10 +834,20 @@ function renderGraph() {
   zoom = d3.zoom().scaleExtent([0.1, 5]).on('zoom', e => { transform = e.transform; });
   d3.select(canvas).call(zoom);
 
-  // D3 drag on canvas via pointer events
-  canvas.onmousedown = onCanvasMouseDown;
-  canvas.onmousemove = onCanvasMouseMove;
-  canvas.onmouseup = onCanvasMouseUp;
+  // Pointer events support mouse and touch node dragging while D3 handles pan/zoom.
+  if (window.PointerEvent) {
+    canvas.onpointerdown = onCanvasPointerDown;
+    canvas.onpointermove = onCanvasPointerMove;
+    canvas.onpointerup = onCanvasPointerUp;
+    canvas.onpointercancel = onCanvasPointerUp;
+    canvas.onmousedown = null;
+    canvas.onmousemove = null;
+    canvas.onmouseup = null;
+  } else {
+    canvas.onmousedown = onCanvasPointerDown;
+    canvas.onmousemove = onCanvasPointerMove;
+    canvas.onmouseup = onCanvasPointerUp;
+  }
   canvas.onclick = onCanvasClick;
   canvas.onmouseleave = () => { hideTooltip(); hoveredNode = null; hoveredEdge = null; };
 
@@ -942,27 +1074,30 @@ function hitEdge(mx, my) {
 }
 
 // ── CANVAS MOUSE EVENTS ───────────────────────────────────────────────────────
-let _dragging = null, _dragMoved = false;
+let _dragging = null, _dragMoved = false, _activePointerId = null;
 
-function onCanvasMouseDown(e) {
-  if (e.button !== 0) return;
+function onCanvasPointerDown(e) {
+  if (e.button !== undefined && e.button !== 0) return;
   const [mx, my] = canvasPoint(e);
   const n = hitNode(mx, my);
   if (n) {
-    _dragging = n; _dragMoved = false;
+    _dragging = n; _dragMoved = false; _activePointerId = e.pointerId ?? null;
+    canvas.setPointerCapture?.(e.pointerId);
     if (!simulation._active) simulation.alphaTarget(0.3).restart();
     n.fx = n.x; n.fy = n.y;
-    // Stop zoom from panning while dragging node
     d3.select(canvas).on('.zoom', null);
+    e.preventDefault();
   }
 }
 
-function onCanvasMouseMove(e) {
+function onCanvasPointerMove(e) {
+  if (_activePointerId !== null && e.pointerId !== undefined && e.pointerId !== _activePointerId) return;
   const [mx, my] = canvasPoint(e);
   if (_dragging) {
     _dragMoved = true;
     _dragging.fx = mx; _dragging.fy = my;
     simulation.alphaTarget(0.15).restart();
+    e.preventDefault();
     return;
   }
   const n = hitNode(mx, my);
@@ -978,12 +1113,14 @@ function onCanvasMouseMove(e) {
   }
 }
 
-function onCanvasMouseUp(e) {
+function onCanvasPointerUp(e) {
+  if (_activePointerId !== null && e.pointerId !== undefined && e.pointerId !== _activePointerId) return;
   if (_dragging) {
     _dragging.fx = null; _dragging.fy = null;
     simulation.alphaTarget(0.004);
+    canvas.releasePointerCapture?.(e.pointerId);
     _dragging = null;
-    // Restore zoom
+    _activePointerId = null;
     d3.select(canvas).call(zoom);
   }
 }
@@ -1065,16 +1202,19 @@ function deselectAll() {
   selectedNode = null; selectedEdge = null;
   document.getElementById('inspector-empty').style.display = '';
   document.getElementById('inspector-content').style.display = 'none';
+  document.getElementById('mobile-bubble-inspector')?.classList.remove('active');
 }
 
 function selectNode(d) {
   selectedNode = d; selectedEdge = null;
   renderInspector(d, 'node');
+  markInspectorReady();
 }
 
 function selectEdge(d) {
   selectedEdge = d; selectedNode = null;
   renderInspector(d, 'edge');
+  markInspectorReady();
 }
 
 function tagHtml(v, positive) {
@@ -1157,6 +1297,26 @@ function toggleSection(id) {
   if (chev) chev.classList.toggle('open', !visible);
 }
 
+function openMobileSheet(section) {
+  document.body.classList.add('mobile-sheet-open');
+  for (const id of ['inspector', 'warnings', 'health']) {
+    const body = document.getElementById('body-' + id);
+    const chev = document.getElementById('chev-' + id);
+    const open = id === section;
+    if (body) body.style.display = open ? '' : 'none';
+    if (chev) chev.classList.toggle('open', open);
+    document.getElementById('mobile-bubble-' + id)?.classList.toggle('active', open);
+  }
+}
+
+function closeMobileSheet() {
+  document.body.classList.remove('mobile-sheet-open');
+}
+
+function markInspectorReady() {
+  document.getElementById('mobile-bubble-inspector')?.classList.add('active');
+}
+
 // ── INIT ──────────────────────────────────────────────────────────────────────
 window.addEventListener('load', () => {
   fetchAll();
@@ -1166,6 +1326,148 @@ window.addEventListener('load', () => {
 
 
 </body></html>"""
+
+
+_MOBILE_PREVIEW_HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mobile Preview - Flux Dashboard</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    min-height: 100vh; padding: 32px 24px 48px; overflow-x: auto;
+    background: #060810; color: #dde3f0; font-family: system-ui, sans-serif;
+  }
+  h1 {
+    margin-bottom: 32px; color: #3a4255; text-align: center;
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.8px;
+  }
+  .devices-row {
+    display: flex; align-items: flex-start; justify-content: center;
+    gap: 40px; flex-wrap: wrap;
+  }
+  .device { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .device-label { font-size: 10px; color: #3a4255; text-transform: uppercase; letter-spacing: 0.6px; }
+  .device-sub { font-size: 10px; color: #22253a; }
+  .iphone-air {
+    width: 280px; background: #1c1c1e; border-radius: 50px;
+    border: 1.5px solid #2c2c2e; position: relative; padding: 14px;
+    box-shadow: 0 0 0 1px #0a0a0c, inset 0 0 0 1px #3a3a3e,
+      0 40px 80px rgba(0,0,0,0.9), 0 0 40px rgba(34,211,238,0.04);
+  }
+  .iphone-air .dynamic-island {
+    position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+    width: 90px; height: 30px; background: #000; border-radius: 20px; z-index: 10;
+  }
+  .iphone-air .screen {
+    width: 100%; height: 580px; border-radius: 38px; overflow: hidden;
+    background: #080a0e; position: relative;
+  }
+  .iphone-air .screen iframe {
+    width: 390px; height: 844px; border: none; display: block;
+    transform: scale(0.642); transform-origin: top left;
+  }
+  .iphone-air .home-bar, .razr-open .home-bar {
+    height: 4px; border-radius: 2px; background: rgba(255,255,255,0.12); margin: 10px auto 0;
+  }
+  .iphone-air .home-bar { width: 80px; }
+  .iphone-air::before {
+    content: ''; position: absolute; right: -3px; top: 120px;
+    width: 3px; height: 60px; background: #2a2a2c; border-radius: 0 3px 3px 0;
+  }
+  .iphone-air::after {
+    content: ''; position: absolute; left: -3px; top: 100px;
+    width: 3px; height: 100px; background: #2a2a2c; border-radius: 3px 0 0 3px;
+    box-shadow: 0 50px 0 #2a2a2c, 0 -50px 0 #2a2a2c;
+  }
+  .razr-open {
+    width: 258px; background: #18181a; border-radius: 30px;
+    border: 1.5px solid #2c2c2e; position: relative; padding: 12px;
+    box-shadow: 0 0 0 1px #0a0a0c, inset 0 0 0 1px #303032, 0 40px 80px rgba(0,0,0,0.9);
+  }
+  .razr-open .hinge-seam {
+    position: absolute; left: 12px; right: 12px; top: 50%; transform: translateY(-50%);
+    height: 6px; background: #0f0f11; border-top: 1px solid #222224;
+    border-bottom: 1px solid #222224; z-index: 20; pointer-events: none;
+  }
+  .razr-open .punch-hole, .razr-folded .punch-hole {
+    position: absolute; left: 50%; transform: translateX(-50%);
+    background: #000; border-radius: 50%; z-index: 10;
+  }
+  .razr-open .punch-hole { top: 18px; width: 10px; height: 10px; }
+  .razr-open .screen {
+    width: 100%; height: 540px; border-radius: 20px; overflow: hidden; background: #080a0e;
+  }
+  .razr-open .screen iframe {
+    width: 360px; height: 780px; border: none; display: block;
+    transform: scale(0.653); transform-origin: top left;
+  }
+  .razr-open .home-bar { width: 70px; }
+  .razr-folded {
+    width: 200px; background: #18181a; border-radius: 24px 24px 8px 8px;
+    border: 1.5px solid #2c2c2e; position: relative; padding: 10px;
+    box-shadow: 0 0 0 1px #0a0a0c, inset 0 0 0 1px #303032, 0 20px 50px rgba(0,0,0,0.9);
+  }
+  .razr-folded .cover-screen {
+    width: 100%; height: 120px; border-radius: 16px 16px 4px 4px;
+    overflow: hidden; background: #080a0e; position: relative;
+  }
+  .razr-folded .cover-screen iframe {
+    width: 390px; height: 162px; border: none; display: block;
+    transform: scale(0.462); transform-origin: top left;
+  }
+  .razr-folded .hinge {
+    height: 14px; background: linear-gradient(180deg, #111113 0%, #1a1a1c 50%, #111113 100%);
+    border-top: 1px solid #2a2a2c; border-bottom: 1px solid #2a2a2c;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .razr-folded .hinge::after { content: ''; width: 40px; height: 3px; border-radius: 2px; background: #222224; }
+  .razr-folded .body-bottom { height: 14px; background: #18181a; border-radius: 0 0 6px 6px; }
+  .razr-folded .punch-hole { top: 10px; width: 9px; height: 9px; }
+  .note { font-size: 10px; color: #2a3040; text-align: center; line-height: 1.7; max-width: 200px; }
+  .note span { color: #22d3ee; }
+</style>
+</head>
+<body>
+<h1>Flux Memory Dashboard - Mobile Layouts</h1>
+<div class="devices-row">
+  <div class="device">
+    <div class="device-label">iPhone Air</div>
+    <div class="device-sub">390 x 844</div>
+    <div class="iphone-air">
+      <div class="dynamic-island"></div>
+      <div class="screen"><iframe src="/" scrolling="no"></iframe></div>
+      <div class="home-bar"></div>
+    </div>
+    <div class="note">Single finger: drag node<br>Two fingers: pan + pinch zoom<br>Tap node -> <span>inspector bubble glows</span><br>Tap bubble -> sheet slides up</div>
+  </div>
+  <div class="device">
+    <div class="device-label">Motorola Razr+</div>
+    <div class="device-sub">360 x 780 unfolded</div>
+    <div class="razr-open">
+      <div class="punch-hole"></div>
+      <div class="hinge-seam"></div>
+      <div class="screen"><iframe src="/" scrolling="no"></iframe></div>
+      <div class="home-bar"></div>
+    </div>
+    <div class="note">Full screen graph<br>Bubble bar at bottom<br>Hinge seam is cosmetic only</div>
+  </div>
+  <div class="device">
+    <div class="device-label">Motorola Razr+</div>
+    <div class="device-sub">390 x 162 folded outer screen</div>
+    <div class="razr-folded">
+      <div class="punch-hole"></div>
+      <div class="cover-screen"><iframe src="/" scrolling="no"></iframe></div>
+      <div class="hinge"></div>
+      <div class="body-bottom"></div>
+    </div>
+    <div class="note">Ultra-compact mode<br>Status + graph only<br><span>No bubbles, no sheets</span><br>Quick glance view</div>
+  </div>
+</div>
+</body>
+</html>"""
 
 
 def _recent_events(store: Any, limit: int = 25) -> dict[str, list[dict[str, Any]]]:
@@ -1215,6 +1517,8 @@ def run_dashboard(
             path = parsed.path
             if path == "/" or path == "/index.html":
                 self._send(200, "text/html; charset=utf-8", _DASHBOARD_HTML.encode())
+            elif path == "/mobile-preview":
+                self._send(200, "text/html; charset=utf-8", _MOBILE_PREVIEW_HTML.encode())
             elif path == "/api/health":
                 data = flux_health(store, cfg) if cfg else flux_health(store)
                 self._send(200, "application/json", json.dumps(data, default=str).encode())

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -186,6 +186,7 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
     padding: 10px 14px; cursor: pointer; user-select: none;
   }
   .rpanel-header-left { display: flex; align-items: center; gap: 6px; }
+  .rpanel-actions { display: flex; align-items: center; gap: 6px; }
   .rpanel-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.6px; color: var(--text-muted); }
   .rpanel-count {
     font-size: 10px; background: var(--surface2); border: 1px solid var(--border);
@@ -195,6 +196,12 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
   .rpanel-body { padding: 0 14px 12px; }
   .rpanel-chevron { color: var(--text-dim); transition: transform 0.2s; }
   .rpanel-chevron.open { transform: rotate(180deg); }
+  .inspector-clear {
+    width: 22px; height: 22px; opacity: 1;
+  }
+  .inspector-clear:disabled {
+    opacity: 0.28; cursor: default; pointer-events: none;
+  }
 
   /* INSPECTOR */
   #inspector-empty {
@@ -507,7 +514,12 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65" stroke-opacity="0.7"></line></svg>
             <span class="rpanel-title">Inspector</span>
           </div>
-          <svg class="rpanel-chevron open" id="chev-inspector" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+          <div class="rpanel-actions">
+            <button class="icon-btn inspector-clear" id="clear-selection-btn" title="Deselect" aria-label="Deselect" disabled onclick="event.stopPropagation(); deselectAll();">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+            </button>
+            <svg class="rpanel-chevron open" id="chev-inspector" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+          </div>
         </div>
         <div class="rpanel-body" id="body-inspector">
           <div id="inspector-empty">
@@ -1213,18 +1225,27 @@ function deselectAll() {
   document.getElementById('inspector-empty').style.display = '';
   document.getElementById('inspector-content').style.display = 'none';
   document.getElementById('mobile-bubble-inspector')?.classList.remove('active');
+  updateSelectionControls();
+  draw();
 }
 
 function selectNode(d) {
   selectedNode = d; selectedEdge = null;
   renderInspector(d, 'node');
+  updateSelectionControls();
   markInspectorReady();
 }
 
 function selectEdge(d) {
   selectedEdge = d; selectedNode = null;
   renderInspector(d, 'edge');
+  updateSelectionControls();
   markInspectorReady();
+}
+
+function updateSelectionControls() {
+  const clearBtn = document.getElementById('clear-selection-btn');
+  if (clearBtn) clearBtn.disabled = !(selectedNode || selectedEdge);
 }
 
 function tagHtml(v, positive) {
@@ -1331,6 +1352,9 @@ function markInspectorReady() {
 window.addEventListener('load', () => {
   fetchAll();
   window.addEventListener('resize', () => { if (graphData) renderGraph(); });
+  window.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && (selectedNode || selectedEdge)) deselectAll();
+  });
 });
 </script>
 

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -16,1161 +16,1106 @@ from urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
 
-_DASHBOARD_HTML = r"""<!DOCTYPE html>
-<html lang="en">
-<head>
+_DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
+
+
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Flux Memory - Dashboard</title>
+<title>Flux Memory — Dashboard</title>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
 <style>
   :root {
     --bg: #080a0e;
     --surface: #0f1117;
-    --surface-2: #151923;
-    --surface-3: #1b2130;
-    --border: #222938;
-    --border-2: #2d3547;
-    --text: #e1e7f3;
-    --muted: #7b8498;
-    --dim: #4e566b;
+    --surface2: #161921;
+    --border: #1e2330;
+    --border2: #252c3a;
+    --text: #dde3f0;
+    --text-muted: #5a6480;
+    --text-dim: #3a4255;
     --cyan: #22d3ee;
-    --cyan-dim: rgba(34, 211, 238, 0.12);
+    --cyan-dim: rgba(34,211,238,0.12);
     --green: #4ade80;
-    --green-dim: rgba(74, 222, 128, 0.12);
+    --green-dim: rgba(74,222,128,0.12);
     --amber: #fbbf24;
-    --amber-dim: rgba(251, 191, 36, 0.13);
-    --rose: #fb7185;
-    --rose-dim: rgba(251, 113, 133, 0.13);
+    --amber-dim: rgba(251,191,36,0.12);
+    --rose: #f43f5e;
+    --rose-dim: rgba(244,63,94,0.12);
     --violet: #a78bfa;
-    --violet-dim: rgba(167, 139, 250, 0.12);
-    --radius: 8px;
-    --mono: "JetBrains Mono", "Fira Code", Consolas, monospace;
-    --ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --violet-dim: rgba(167,139,250,0.12);
+    --radius: 6px;
+    --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+    --font-ui: 'Inter', system-ui, sans-serif;
   }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; background: var(--bg); color: var(--text); font-family: var(--font-ui); font-size: 13px; overflow: hidden; }
 
-  * { box-sizing: border-box; }
-  html, body { height: 100%; }
-  body {
-    margin: 0;
-    min-width: 320px;
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--ui);
-    font-size: 13px;
-    letter-spacing: 0;
-    overflow: hidden;
-  }
-  button, input { font: inherit; }
-  button { color: inherit; }
+  /* LAYOUT */
   #app { display: flex; flex-direction: column; height: 100vh; }
 
+  /* TOP BAR */
   #topbar {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 14px;
+    display: flex; align-items: center; gap: 12px;
+    padding: 10px 16px;
     background: var(--surface);
     border-bottom: 1px solid var(--border);
     flex-shrink: 0;
+    flex-wrap: wrap;
   }
-  .brand {
-    display: flex;
-    align-items: center;
-    gap: 9px;
-    min-width: 170px;
-  }
-  .brand-mark {
-    display: grid;
-    place-items: center;
-    width: 30px;
-    height: 30px;
-    border-radius: 7px;
-    background: linear-gradient(180deg, #172033, #101723);
-    border: 1px solid var(--border-2);
-    color: var(--cyan);
-    font-weight: 800;
-  }
-  .brand-name { font-weight: 700; font-size: 14px; line-height: 1.15; }
-  .brand-sub { color: var(--muted); font-family: var(--mono); font-size: 10px; margin-top: 2px; }
-  .divider { width: 1px; align-self: stretch; background: var(--border); }
+  #topbar .brand { display: flex; align-items: center; gap: 8px; margin-right: 4px; }
+  #topbar .brand svg { flex-shrink: 0; }
+  #topbar .brand-name { font-size: 14px; font-weight: 600; letter-spacing: -0.3px; color: var(--text); }
+  #topbar .brand-sub { font-size: 11px; color: var(--text-muted); }
   #status-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    height: 26px;
-    padding: 0 10px;
-    border-radius: 999px;
-    font-size: 11px;
-    font-weight: 800;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    display: flex; align-items: center; gap: 5px;
+    padding: 3px 9px; border-radius: 20px; font-size: 11px; font-weight: 600;
+    letter-spacing: 0.4px; text-transform: uppercase;
   }
-  .badge-healthy { background: var(--green-dim); color: var(--green); border: 1px solid rgba(74, 222, 128, 0.28); }
-  .badge-warning { background: var(--amber-dim); color: var(--amber); border: 1px solid rgba(251, 191, 36, 0.3); }
-  .badge-critical { background: var(--rose-dim); color: var(--rose); border: 1px solid rgba(251, 113, 133, 0.3); }
-  .pulse {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: currentColor;
-    animation: pulse 2s ease-in-out infinite;
-  }
+  .badge-healthy { background: var(--green-dim); color: var(--green); border: 1px solid rgba(74,222,128,0.3); }
+  .badge-warning { background: var(--amber-dim); color: var(--amber); border: 1px solid rgba(251,191,36,0.3); }
+  .badge-critical { background: var(--rose-dim); color: var(--rose); border: 1px solid rgba(244,63,94,0.3); }
+  .pulse { width: 6px; height: 6px; border-radius: 50%; animation: pulse 2s ease-in-out infinite; }
+  .pulse-green { background: var(--green); box-shadow: 0 0 0 0 rgba(74,222,128,0.6); }
+  .pulse-amber { background: var(--amber); box-shadow: 0 0 0 0 rgba(251,191,36,0.6); }
+  .pulse-rose { background: var(--rose); box-shadow: 0 0 0 0 rgba(244,63,94,0.6); }
   @keyframes pulse {
-    0%, 100% { transform: scale(1); opacity: 1; }
-    50% { transform: scale(1.45); opacity: 0.55; }
+    0%,100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.4); opacity: 0.6; }
   }
-  #metrics-strip {
-    display: grid;
-    grid-template-columns: repeat(6, minmax(86px, 1fr));
-    gap: 6px;
-    flex: 1;
-    min-width: 0;
-  }
+  .divider { width: 1px; height: 20px; background: var(--border2); flex-shrink: 0; }
+  #metrics-strip { display: flex; gap: 2px; flex: 1; flex-wrap: wrap; }
   .metric-pill {
-    min-width: 0;
-    padding: 5px 9px;
-    border-radius: var(--radius);
-    background: var(--surface-2);
-    border: 1px solid var(--border);
+    display: flex; flex-direction: column; align-items: flex-start;
+    padding: 4px 12px; background: var(--surface2); border: 1px solid var(--border);
+    border-radius: var(--radius); min-width: 80px; cursor: default;
+    transition: border-color 0.15s;
   }
-  .metric-pill .label {
-    color: var(--muted);
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .metric-pill .value {
-    margin-top: 1px;
-    color: var(--text);
-    font-family: var(--mono);
-    font-size: 16px;
-    font-weight: 800;
-    line-height: 1.2;
-  }
-  .value-cyan { color: var(--cyan) !important; }
-  .value-green { color: var(--green) !important; }
-  .value-amber { color: var(--amber) !important; }
-  .value-rose { color: var(--rose) !important; }
-  #topbar-controls {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-  }
-  #computed-at {
-    color: var(--dim);
-    font-family: var(--mono);
-    font-size: 10px;
-    white-space: nowrap;
-  }
+  .metric-pill:hover { border-color: var(--border2); }
+  .metric-pill .m-label { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .metric-pill .m-value { font-size: 16px; font-weight: 700; font-family: var(--font-mono); color: var(--text); line-height: 1.2; margin-top: 1px; }
+  .metric-pill .m-value.c-cyan { color: var(--cyan); }
+  .metric-pill .m-value.c-green { color: var(--green); }
+  .metric-pill .m-value.c-amber { color: var(--amber); }
+  .metric-pill .m-value.c-rose { color: var(--rose); }
+  #topbar-controls { display: flex; align-items: center; gap: 6px; margin-left: auto; }
+  #computed-at { font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); white-space: nowrap; }
   .icon-btn {
-    display: inline-grid;
-    place-items: center;
-    width: 30px;
-    height: 30px;
-    padding: 0;
-    border-radius: var(--radius);
-    border: 1px solid var(--border);
-    background: var(--surface-2);
-    color: var(--muted);
-    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    width: 28px; height: 28px; border-radius: var(--radius);
+    background: var(--surface2); border: 1px solid var(--border);
+    color: var(--text-muted); cursor: pointer; transition: all 0.15s;
   }
-  .icon-btn:hover { color: var(--text); border-color: var(--border-2); background: var(--surface-3); }
-  .icon-btn.active { color: var(--cyan); border-color: rgba(34, 211, 238, 0.35); background: var(--cyan-dim); }
+  .icon-btn:hover { color: var(--text); border-color: var(--border2); }
+  .icon-btn.active { color: var(--cyan); border-color: rgba(34,211,238,0.3); background: var(--cyan-dim); }
+  #refresh-interval { font-size: 11px; color: var(--text-muted); }
 
-  #main { display: flex; flex: 1; min-height: 0; overflow: hidden; }
-  #graph-panel {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    border-right: 1px solid var(--border);
-  }
+  /* MAIN AREA */
+  #main { display: flex; flex: 1; overflow: hidden; }
+
+  /* LEFT: GRAPH PANEL */
+  #graph-panel { flex: 1; display: flex; flex-direction: column; min-width: 0; border-right: 1px solid var(--border); }
   #graph-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 12px;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border);
-    flex-shrink: 0;
+    display: flex; align-items: center; gap: 8px; padding: 8px 12px;
+    background: var(--surface); border-bottom: 1px solid var(--border); flex-shrink: 0; flex-wrap: wrap;
   }
   #search-box {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    width: 230px;
-    min-width: 160px;
-    height: 30px;
-    padding: 0 9px;
-    border-radius: var(--radius);
-    background: var(--surface-2);
-    border: 1px solid var(--border);
-    color: var(--muted);
+    display: flex; align-items: center; gap: 6px;
+    background: var(--surface2); border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 4px 8px; flex: 1; max-width: 220px;
   }
-  #search-input {
-    width: 100%;
-    min-width: 0;
-    outline: none;
-    border: 0;
-    color: var(--text);
-    background: transparent;
-    font-size: 12px;
+  #search-box input {
+    background: none; border: none; outline: none; color: var(--text);
+    font-size: 12px; font-family: var(--font-ui); width: 100%;
   }
-  #search-input::placeholder { color: var(--dim); }
-  .filter-group { display: flex; align-items: center; gap: 4px; }
+  #search-box input::placeholder { color: var(--text-dim); }
+  .filter-group { display: flex; align-items: center; gap: 3px; }
   .filter-btn {
-    height: 28px;
-    padding: 0 9px;
-    border-radius: var(--radius);
-    border: 1px solid var(--border);
-    background: var(--surface-2);
-    color: var(--muted);
-    font-size: 11px;
-    font-weight: 700;
-    cursor: pointer;
+    padding: 3px 8px; border-radius: var(--radius); font-size: 11px; font-weight: 500;
+    border: 1px solid var(--border); background: var(--surface2); color: var(--text-muted);
+    cursor: pointer; transition: all 0.15s;
   }
-  .filter-btn.active { color: var(--cyan); border-color: rgba(34, 211, 238, 0.35); background: var(--cyan-dim); }
-  .filter-btn.active.violet { color: var(--violet); border-color: rgba(167, 139, 250, 0.35); background: var(--violet-dim); }
-  .slider-group {
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    color: var(--muted);
-    font-size: 10px;
-    font-weight: 800;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    white-space: nowrap;
-  }
-  #weight-slider { width: 92px; accent-color: var(--cyan); cursor: pointer; }
-  #weight-val { min-width: 30px; color: var(--cyan); font-family: var(--mono); font-size: 11px; }
-  #graph-container {
-    position: relative;
-    flex: 1;
-    min-height: 0;
-    background:
-      linear-gradient(rgba(34, 211, 238, 0.025) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(34, 211, 238, 0.025) 1px, transparent 1px),
-      #070a0f;
-    background-size: 32px 32px;
-    overflow: hidden;
-  }
-  #graph-svg { width: 100%; height: 100%; display: block; }
-  #graph-stats {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    display: flex;
-    gap: 8px;
-    padding: 6px 9px;
-    border-radius: var(--radius);
-    border: 1px solid var(--border);
-    background: rgba(15, 17, 23, 0.82);
-    color: var(--muted);
-    font-family: var(--mono);
-    font-size: 10px;
-    backdrop-filter: blur(6px);
-  }
+  .filter-btn.active { background: var(--cyan-dim); border-color: rgba(34,211,238,0.35); color: var(--cyan); }
+  .filter-btn.active.violet { background: var(--violet-dim); border-color: rgba(167,139,250,0.35); color: var(--violet); }
+  .slider-group { display: flex; align-items: center; gap: 6px; }
+  .slider-group label { font-size: 10px; color: var(--text-muted); white-space: nowrap; text-transform: uppercase; letter-spacing: 0.4px; }
+  #weight-slider { width: 80px; accent-color: var(--cyan); cursor: pointer; }
+  #weight-val { font-size: 11px; font-family: var(--font-mono); color: var(--cyan); min-width: 28px; }
+  #graph-container { flex: 1; position: relative; overflow: hidden; }
+  #graph-canvas { width: 100%; height: 100%; display: block; cursor: grab; }
+  #graph-canvas.dragging { cursor: grabbing; }
   #graph-overlay {
-    position: absolute;
-    left: 12px;
-    bottom: 12px;
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    padding: 6px 8px;
-    border-radius: var(--radius);
-    border: 1px solid rgba(34, 41, 56, 0.72);
-    background: rgba(15, 17, 23, 0.72);
-    backdrop-filter: blur(6px);
+    position: absolute; bottom: 12px; left: 12px;
+    display: flex; gap: 8px; flex-wrap: wrap;
   }
-  .legend-item { display: inline-flex; align-items: center; gap: 5px; color: var(--muted); font-size: 10px; }
-  .legend-dot { width: 8px; height: 8px; border-radius: 50%; }
-  #no-data-msg, #error-msg {
-    position: absolute;
-    inset: 0;
-    display: none;
-    align-items: center;
-    justify-content: center;
-    color: var(--dim);
-    font-size: 13px;
-    text-align: center;
-    padding: 20px;
+  .legend-item { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-muted); }
+  .legend-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  #tooltip {
+    position: fixed; pointer-events: none; z-index: 999;
+    background: var(--surface); border: 1px solid var(--border2);
+    border-radius: var(--radius); padding: 8px 10px; max-width: 260px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.5); opacity: 0; transition: opacity 0.1s;
+    font-size: 11px; line-height: 1.6;
   }
-  #error-msg { color: var(--rose); }
+  #tooltip .tt-title { font-size: 12px; font-weight: 600; color: var(--text); margin-bottom: 4px; }
+  #tooltip .tt-row { display: flex; justify-content: space-between; gap: 12px; }
+  #tooltip .tt-key { color: var(--text-muted); }
+  #tooltip .tt-val { font-family: var(--font-mono); color: var(--text); }
+  #graph-stats {
+    position: absolute; top: 10px; right: 10px;
+    background: rgba(15,17,23,0.8); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 5px 9px; font-size: 10px;
+    font-family: var(--font-mono); color: var(--text-muted);
+    backdrop-filter: blur(4px);
+  }
+  #no-data-msg {
+    position: absolute; inset: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 8px;
+    color: var(--text-dim); font-size: 13px; display: none;
+  }
 
+  /* RIGHT PANEL */
   #right-panel {
-    width: 340px;
-    flex-shrink: 0;
-    background: var(--surface);
-    overflow: auto;
+    width: 320px; flex-shrink: 0; display: flex; flex-direction: column;
+    background: var(--surface); overflow-y: auto; overflow-x: hidden;
   }
-  .r-section { border-bottom: 1px solid var(--border); }
-  .r-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    padding: 11px 14px;
-    cursor: pointer;
-    user-select: none;
+  .rpanel-section {
+    border-bottom: 1px solid var(--border); flex-shrink: 0;
   }
-  .r-title-wrap { display: flex; align-items: center; gap: 7px; min-width: 0; }
-  .r-title {
-    color: var(--muted);
-    font-size: 11px;
-    font-weight: 800;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+  .rpanel-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 14px; cursor: pointer; user-select: none;
   }
-  .r-count {
-    min-width: 20px;
-    padding: 1px 6px;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-    background: var(--surface-2);
-    color: var(--muted);
-    font-family: var(--mono);
-    font-size: 10px;
-    text-align: center;
+  .rpanel-header-left { display: flex; align-items: center; gap: 6px; }
+  .rpanel-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.6px; color: var(--text-muted); }
+  .rpanel-count {
+    font-size: 10px; background: var(--surface2); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1px 6px; font-family: var(--font-mono); color: var(--text-muted);
   }
-  .r-count.warn { color: var(--amber); border-color: rgba(251, 191, 36, 0.3); background: var(--amber-dim); }
-  .r-body { padding: 0 14px 13px; }
-  .chev { color: var(--dim); transition: transform 0.2s; }
-  .chev.open { transform: rotate(180deg); }
+  .rpanel-count.warn { background: var(--amber-dim); border-color: rgba(251,191,36,0.3); color: var(--amber); }
+  .rpanel-body { padding: 0 14px 12px; }
+  .rpanel-chevron { color: var(--text-dim); transition: transform 0.2s; }
+  .rpanel-chevron.open { transform: rotate(180deg); }
 
+  /* INSPECTOR */
   #inspector-empty {
-    padding: 22px 0;
-    color: var(--dim);
-    font-size: 12px;
-    text-align: center;
+    padding: 24px 14px; text-align: center; color: var(--text-dim); font-size: 11px; line-height: 1.6;
   }
-  .node-head { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 11px; }
-  .node-icon {
-    display: grid;
-    place-items: center;
-    width: 34px;
-    height: 34px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-  .node-label { color: var(--text); font-size: 12px; font-weight: 700; line-height: 1.35; word-break: break-word; }
-  .node-type { margin-top: 3px; color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
-  .kv { display: flex; flex-direction: column; gap: 5px; }
-  .kv-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 10px;
-    padding: 5px 0;
-    border-bottom: 1px solid rgba(34, 41, 56, 0.72);
-  }
-  .kv-row:last-child { border-bottom: 0; }
-  .kv-key { color: var(--muted); font-size: 11px; flex-shrink: 0; }
-  .kv-val {
-    color: var(--text);
-    font-family: var(--mono);
-    font-size: 11px;
-    text-align: right;
-    word-break: break-all;
-  }
-  .tag {
-    display: inline-block;
-    max-width: 160px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: bottom;
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-size: 10px;
-    font-weight: 800;
-  }
+  .inspector-node-header { display: flex; align-items: flex-start; gap: 8px; margin-bottom: 10px; }
+  .inspector-icon { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .inspector-label { font-size: 12px; font-weight: 600; color: var(--text); line-height: 1.4; word-break: break-word; }
+  .inspector-type { font-size: 10px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.4px; margin-top: 2px; }
+  .inspector-rows { display: flex; flex-direction: column; gap: 4px; }
+  .inspector-row { display: flex; justify-content: space-between; align-items: flex-start; gap: 8px; padding: 3px 0; border-bottom: 1px solid var(--border); }
+  .inspector-row:last-child { border-bottom: none; }
+  .ir-key { font-size: 11px; color: var(--text-muted); flex-shrink: 0; }
+  .ir-val { font-size: 11px; font-family: var(--font-mono); color: var(--text); text-align: right; word-break: break-all; }
+  .tag { display: inline-block; padding: 1px 5px; border-radius: 3px; font-size: 10px; font-weight: 500; }
   .tag-cyan { background: var(--cyan-dim); color: var(--cyan); }
   .tag-violet { background: var(--violet-dim); color: var(--violet); }
   .tag-green { background: var(--green-dim); color: var(--green); }
   .tag-amber { background: var(--amber-dim); color: var(--amber); }
   .tag-rose { background: var(--rose-dim); color: var(--rose); }
-  .tag-dim { background: var(--surface-2); color: var(--muted); }
+  .tag-dim { background: var(--surface2); color: var(--text-muted); }
 
+  /* WARNINGS */
   .warning-card {
-    padding: 9px 10px;
-    margin-bottom: 7px;
-    border-radius: var(--radius);
-    border: 1px solid rgba(251, 191, 36, 0.22);
-    background: rgba(251, 191, 36, 0.07);
+    background: var(--surface2); border: 1px solid rgba(251,191,36,0.2);
+    border-radius: var(--radius); padding: 8px 10px; margin-bottom: 6px;
   }
   .warning-card:last-child { margin-bottom: 0; }
-  .warning-signal { color: var(--amber); font-family: var(--mono); font-size: 11px; font-weight: 800; }
-  .warning-msg { margin-top: 4px; color: #c5cede; font-size: 11px; line-height: 1.45; }
-  .warning-val { margin-top: 6px; color: var(--dim); font-family: var(--mono); font-size: 10px; }
-  .empty-row { color: var(--dim); font-size: 11px; padding: 8px 0; }
+  .warning-signal { font-size: 11px; font-weight: 600; color: var(--amber); font-family: var(--font-mono); }
+  .warning-msg { font-size: 11px; color: var(--text-muted); margin-top: 3px; line-height: 1.5; }
+  .warning-val { font-size: 10px; color: var(--text-dim); margin-top: 4px; font-family: var(--font-mono); }
 
-  .health-group { margin-bottom: 11px; }
-  .health-group:last-child { margin-bottom: 0; }
-  .health-label {
-    margin-bottom: 5px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--border);
-    color: var(--dim);
-    font-size: 10px;
-    font-weight: 800;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-  }
-  .health-row { display: flex; align-items: center; gap: 7px; padding: 4px 0; }
-  .health-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
-  .health-key { flex: 1; min-width: 0; color: var(--muted); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .health-val { min-width: 52px; color: var(--text); font-family: var(--mono); font-size: 11px; text-align: right; }
+  /* HEALTH TABLE */
+  .health-group { margin-bottom: 10px; }
+  .health-group-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-dim); margin-bottom: 4px; padding-bottom: 3px; border-bottom: 1px solid var(--border); }
+  .health-row { display: flex; align-items: center; gap: 6px; padding: 3px 0; }
+  .health-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .health-row-key { flex: 1; font-size: 11px; color: var(--text-muted); }
+  .health-row-val { font-size: 11px; font-family: var(--font-mono); color: var(--text); min-width: 44px; text-align: right; }
 
-  .event-card {
-    padding: 7px 0;
-    border-bottom: 1px solid rgba(34, 41, 56, 0.72);
-  }
-  .event-card:last-child { border-bottom: 0; }
-  .event-line { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-  .event-name { color: var(--text); font-family: var(--mono); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .event-time { color: var(--dim); font-family: var(--mono); font-size: 10px; flex-shrink: 0; }
-  .event-data { margin-top: 3px; color: var(--muted); font-size: 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-  #tooltip {
-    position: fixed;
-    z-index: 999;
-    pointer-events: none;
-    max-width: 280px;
-    padding: 9px 10px;
-    border-radius: var(--radius);
-    border: 1px solid var(--border-2);
-    background: rgba(15, 17, 23, 0.97);
-    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
-    opacity: 0;
-    transition: opacity 0.1s;
-  }
-  .tt-title { color: var(--text); font-weight: 800; font-size: 12px; line-height: 1.35; margin-bottom: 5px; }
-  .tt-row { display: flex; justify-content: space-between; gap: 16px; line-height: 1.6; }
-  .tt-key { color: var(--muted); }
-  .tt-val { color: var(--text); font-family: var(--mono); }
-
-  ::-webkit-scrollbar { width: 6px; height: 6px; }
-  ::-webkit-scrollbar-thumb { background: var(--border-2); border-radius: 999px; }
+  /* SCROLLBAR */
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border2); border-radius: 2px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
 
-  @media (max-width: 1120px) {
-    #metrics-strip { grid-template-columns: repeat(3, minmax(86px, 1fr)); }
-    #computed-at { display: none; }
+  /* NODE BREATHING */
+  @keyframes node-breathe {
+    0%, 100% { r: 8; opacity: 0.9; }
+    50% { r: 9.5; opacity: 1; }
   }
-  @media (max-width: 860px) {
-    body { overflow: auto; }
-    #app { height: auto; min-height: 100vh; }
-    #topbar, #graph-toolbar { flex-wrap: wrap; }
-    #main { flex-direction: column; overflow: visible; }
-    #graph-panel { min-height: 620px; border-right: 0; border-bottom: 1px solid var(--border); }
-    #right-panel { width: auto; }
-    #metrics-strip { order: 4; flex-basis: 100%; grid-template-columns: repeat(2, minmax(86px, 1fr)); }
-    #search-box { flex: 1; width: auto; max-width: none; }
+  @keyframes core-breathe {
+    0%, 100% { r: 10; opacity: 0.9; }
+    50% { r: 12; opacity: 1; }
+  }
+  @keyframes glow-pulse {
+    0%, 100% { opacity: 0.1; r: 14; }
+    50% { opacity: 0.28; r: 18; }
+  }
+  .node-grain-working { animation: node-breathe 3.5s ease-in-out infinite; }
+  .node-grain-core { animation: core-breathe 2.8s ease-in-out infinite; }
+  .node-glow { animation: glow-pulse 2.8s ease-in-out infinite; }
+
+  /* LOADING OVERLAY */
+  #loading {
+    position: fixed; inset: 0; background: var(--bg);
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 16px; z-index: 1000;
+  }
+  .loader-ring {
+    width: 40px; height: 40px; border-radius: 50%;
+    border: 2px solid var(--border2); border-top-color: var(--cyan);
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  #loading .load-text { font-size: 12px; color: var(--text-muted); font-family: var(--font-mono); }
+
+  /* RESPONSIVE */
+  @media (max-width: 768px) {
+    #main { flex-direction: column; }
+    #right-panel { width: 100%; height: 300px; border-top: 1px solid var(--border); }
+    #graph-panel { border-right: none; }
   }
 </style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;600&amp;display=swap" rel="stylesheet">
 </head>
 <body>
-<div id="app">
-  <header id="topbar">
-    <div class="brand">
-      <div class="brand-mark">F</div>
-      <div>
-        <div class="brand-name">Flux Memory</div>
-        <div class="brand-sub">instance dashboard</div>
-      </div>
-    </div>
-    <div id="status-badge" class="badge-warning"><span class="pulse"></span><span id="status-text">loading</span></div>
-    <div class="divider"></div>
-    <div id="metrics-strip">
-      <div class="metric-pill"><div class="label">Grains</div><div class="value value-cyan" id="m-grains">-</div></div>
-      <div class="metric-pill"><div class="label">Entries</div><div class="value" id="m-entries">-</div></div>
-      <div class="metric-pill"><div class="label">Conduits</div><div class="value value-green" id="m-conduits">-</div></div>
-      <div class="metric-pill"><div class="label">Embeddings</div><div class="value value-green" id="m-embeddings">-</div></div>
-      <div class="metric-pill"><div class="label">Retrieval</div><div class="value" id="m-retrieval">-</div></div>
-      <div class="metric-pill"><div class="label">Fallback</div><div class="value" id="m-fallback">-</div></div>
-    </div>
-    <div id="topbar-controls">
-      <span id="computed-at">not computed</span>
-      <button class="icon-btn" id="autorefresh-btn" type="button" title="Auto refresh" aria-label="Auto refresh">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v7h-7"/></svg>
-      </button>
-      <button class="icon-btn" id="refresh-btn" type="button" title="Refresh" aria-label="Refresh">
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
-      </button>
-    </div>
-  </header>
 
-  <main id="main">
-    <section id="graph-panel">
-      <div id="graph-toolbar">
-        <div id="search-box">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-          <input id="search-input" type="text" placeholder="Search nodes">
-        </div>
-        <div class="filter-group">
-          <button class="filter-btn active" id="f-grain" type="button">Grains</button>
-          <button class="filter-btn violet active" id="f-entry" type="button">Entries</button>
-          <button class="filter-btn active" id="f-active" type="button">Active</button>
-          <button class="filter-btn" id="f-dormant" type="button">Dormant</button>
-        </div>
-        <div class="slider-group">
-          <label for="weight-slider">Min weight</label>
-          <input id="weight-slider" type="range" min="0" max="1" step="0.01" value="0">
-          <span id="weight-val">0.00</span>
-        </div>
-        <button class="icon-btn" id="pause-btn" type="button" title="Pause layout" aria-label="Pause layout">
-          <svg id="pause-icon" width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
-        </button>
-        <button class="icon-btn" id="reset-btn" type="button" title="Reset view" aria-label="Reset view">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/></svg>
-        </button>
-      </div>
-      <div id="graph-container">
-        <svg id="graph-svg"></svg>
-        <div id="graph-stats"><span>nodes: <b id="gs-nodes">0</b></span><span>edges: <b id="gs-edges">0</b></span></div>
-        <div id="graph-overlay">
-          <span class="legend-item"><i class="legend-dot" style="background:var(--violet)"></i>Entry</span>
-          <span class="legend-item"><i class="legend-dot" style="background:var(--cyan)"></i>Working</span>
-          <span class="legend-item"><i class="legend-dot" style="background:#e0f2fe"></i>Core</span>
-          <span class="legend-item"><i class="legend-dot" style="background:var(--green)"></i>Strong</span>
-        </div>
-        <div id="no-data-msg">No graph data</div>
-        <div id="error-msg"></div>
-      </div>
-    </section>
-
-    <aside id="right-panel">
-      <section class="r-section">
-        <div class="r-header" data-section="inspector">
-          <div class="r-title-wrap"><span class="r-title">Inspector</span></div>
-          <svg class="chev open" id="chev-inspector" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
-        </div>
-        <div class="r-body" id="body-inspector">
-          <div id="inspector-empty">No selection</div>
-          <div id="inspector-content" style="display:none"></div>
-        </div>
-      </section>
-
-      <section class="r-section">
-        <div class="r-header" data-section="warnings">
-          <div class="r-title-wrap"><span class="r-title">Warnings</span><span class="r-count warn" id="warnings-count">0</span></div>
-          <svg class="chev open" id="chev-warnings" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
-        </div>
-        <div class="r-body" id="body-warnings"><div id="warnings-list"></div></div>
-      </section>
-
-      <section class="r-section">
-        <div class="r-header" data-section="health">
-          <div class="r-title-wrap"><span class="r-title">Health Signals</span></div>
-          <svg class="chev open" id="chev-health" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
-        </div>
-        <div class="r-body" id="body-health"><div id="health-table"></div></div>
-      </section>
-
-      <section class="r-section">
-        <div class="r-header" data-section="events">
-          <div class="r-title-wrap"><span class="r-title">Recent Activity</span></div>
-          <svg class="chev open" id="chev-events" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg>
-        </div>
-        <div class="r-body" id="body-events"><div id="events-list"></div></div>
-      </section>
-    </aside>
-  </main>
+<div id="loading">
+  <div class="loader-ring"></div>
+  <div class="load-text">Initialising Flux Memory…</div>
 </div>
 
-<div id="tooltip">
+<div id="tooltip" style="opacity: 0;">
   <div class="tt-title" id="tt-title"></div>
   <div id="tt-body"></div>
 </div>
 
+<div id="app">
+  <!-- TOP BAR -->
+  <div id="topbar">
+    <div class="brand">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="12" r="10" stroke="#22d3ee" stroke-width="1.5" opacity="0.3"></circle>
+        <circle cx="12" cy="12" r="6" stroke="#22d3ee" stroke-width="1.5" opacity="0.6"></circle>
+        <circle cx="12" cy="12" r="2.5" fill="#22d3ee"></circle>
+        <line x1="12" y1="2" x2="12" y2="6" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+        <line x1="12" y1="18" x2="12" y2="22" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+        <line x1="2" y1="12" x2="6" y2="12" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+        <line x1="18" y1="12" x2="22" y2="12" stroke="#22d3ee" stroke-width="1.5" opacity="0.5" stroke-opacity="0.7"></line>
+      </svg>
+      <div>
+        <div class="brand-name">Flux Memory</div>
+        <div class="brand-sub" id="instance-name">test1</div>
+      </div>
+    </div>
+    <div id="status-badge" class="badge-warning">
+      <div class="pulse pulse-amber"></div>
+      <span id="status-text">WARNING</span>
+    </div>
+    <div class="divider"></div>
+    <div id="metrics-strip">
+      <div class="metric-pill"><span class="m-label">Grains</span><span class="m-value c-cyan" id="m-grains">-</span></div>
+      <div class="metric-pill"><span class="m-label">Entries</span><span class="m-value" id="m-entries">-</span></div>
+      <div class="metric-pill"><span class="m-label">Conduits</span><span class="m-value" id="m-conduits">-</span></div>
+      <div class="metric-pill"><span class="m-label">Embeddings</span><span class="m-value" id="m-embed">-</span></div>
+      <div class="metric-pill"><span class="m-label">Retrieval</span><span class="m-value c-green" id="m-retrieval">-</span></div>
+      <div class="metric-pill"><span class="m-label">Fallback</span><span class="m-value c-rose" id="m-fallback">-</span></div>
+      <div class="metric-pill"><span class="m-label">Feedback</span><span class="m-value c-rose" id="m-feedback">-</span></div>
+    </div>
+    <div class="divider"></div>
+    <div id="topbar-controls">
+      <span id="computed-at">loading</span>
+      <button class="icon-btn" id="refresh-btn" title="Refresh now" onclick="fetchAll()">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>
+      </button>
+      <button class="icon-btn" id="autorefresh-btn" title="Toggle auto-refresh" onclick="toggleAutoRefresh()">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline></svg>
+      </button>
+      <span id="refresh-interval" style="display: none;">30s</span>
+    </div>
+  </div>
+
+  <!-- MAIN -->
+  <div id="main">
+
+    <!-- GRAPH PANEL -->
+    <div id="graph-panel">
+      <div id="graph-toolbar">
+        <div id="search-box">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#5a6480" stroke-width="2.5"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65" stroke-opacity="0.7"></line></svg>
+          <input type="text" id="search-input" placeholder="Search nodes…" oninput="onSearch(this.value)">
+        </div>
+        <div class="filter-group">
+          <span style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.4px">Type</span>
+          <button class="filter-btn active" id="f-grain" onclick="toggleFilter('grain')">Grains</button>
+          <button class="filter-btn violet active" id="f-entry" onclick="toggleFilter('entry')">Entries</button>
+        </div>
+        <div class="filter-group">
+          <span style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.4px">Status</span>
+          <button class="filter-btn active" id="f-active" onclick="toggleFilter('active')">Active</button>
+          <button class="filter-btn" id="f-dormant" onclick="toggleFilter('dormant')">Dormant</button>
+        </div>
+        <div class="slider-group">
+          <label>Weight ≥</label>
+          <input type="range" id="weight-slider" min="0" max="1" step="0.05" value="0" oninput="onWeightChange(this.value)">
+          <span id="weight-val">0.00</span>
+        </div>
+        <div style="margin-left:auto;display:flex;gap:4px">
+          <button class="icon-btn" id="pause-btn" title="Pause/resume layout" onclick="toggleSimulation()">
+            <svg id="pause-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"></rect><rect x="14" y="4" width="4" height="16"></rect></svg>
+          </button>
+          <button class="icon-btn" title="Reset view" onclick="resetView()">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path><path d="M3 3v5h5"></path></svg>
+          </button>
+        </div>
+      </div>
+
+      <div id="graph-container">
+        <canvas id="graph-canvas" style="width:100%;height:100%;display:block;"></canvas>
+        <div id="graph-stats">nodes: <span id="gs-nodes">0</span> · edges: <span id="gs-edges">0</span></div>
+        <div id="graph-overlay">
+          <div class="legend-item"><div class="legend-dot" style="background:#22d3ee"></div>Grain (working)</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#e0f2fe"></div>Grain (core)</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#a78bfa"></div>Entry</div>
+          <div class="legend-item"><div class="legend-dot" style="background:#334155"></div>Dormant</div>
+        </div>
+        <div id="no-data-msg" style="display: none;">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.4"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12" stroke-opacity="0.7"></line><line x1="12" y1="16" x2="12.01" y2="16" stroke-opacity="0.7"></line></svg>
+          No graph data
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT PANEL -->
+    <div id="right-panel">
+
+      <!-- INSPECTOR -->
+      <div class="rpanel-section">
+        <div class="rpanel-header" onclick="toggleSection('inspector')">
+          <div class="rpanel-header-left">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65" stroke-opacity="0.7"></line></svg>
+            <span class="rpanel-title">Inspector</span>
+          </div>
+          <svg class="rpanel-chevron open" id="chev-inspector" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+        </div>
+        <div class="rpanel-body" id="body-inspector">
+          <div id="inspector-empty">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.3"><rect x="3" y="3" width="18" height="18" rx="2"></rect><line x1="9" y1="9" x2="15" y2="15" stroke-opacity="0.7"></line><line x1="15" y1="9" x2="9" y2="15" stroke-opacity="0.7"></line></svg>
+            <div style="margin-top:8px">Click a node or edge<br>to inspect its properties</div>
+          </div>
+          <div id="inspector-content" style="display: none;"></div>
+        </div>
+      </div>
+
+      <!-- WARNINGS -->
+      <div class="rpanel-section">
+        <div class="rpanel-header" onclick="toggleSection('warnings')">
+          <div class="rpanel-header-left">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13" stroke-opacity="0.7"></line><line x1="12" y1="17" x2="12.01" y2="17" stroke-opacity="0.7"></line></svg>
+            <span class="rpanel-title">Warnings</span>
+            <span class="rpanel-count warn" id="warn-count">0</span>
+          </div>
+          <svg class="rpanel-chevron open" id="chev-warnings" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+        </div>
+        <div class="rpanel-body" id="body-warnings">
+          <div id="warnings-list" style="color:var(--text-dim);font-size:11px">Loading warnings...</div>
+        </div>
+      </div>
+
+      <!-- HEALTH SIGNALS -->
+      <div class="rpanel-section">
+        <div class="rpanel-header" onclick="toggleSection('health')">
+          <div class="rpanel-header-left">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+            <span class="rpanel-title">Health Signals</span>
+          </div>
+          <svg class="rpanel-chevron open" id="chev-health" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="18 15 12 9 6 15"></polyline></svg>
+        </div>
+        <div class="rpanel-body" id="body-health">
+          <div id="health-table" style="color:var(--text-dim);font-size:11px">Loading health signals...</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
 <script>
-let healthData = null;
-let graphData = null;
-let eventsData = [];
-let svg = null;
-let graphLayer = null;
-let simulation = null;
-let zoomBehavior = null;
-let nodeSelectionGlobal = null;
-let linkSelectionGlobal = null;
-let dashFrame = null;
-let dashOffset = 0;
-let autoRefreshTimer = null;
-let simulationPaused = false;
-let activeFilters = { grain: true, entry: true, active: true, dormant: false };
+// -- STATE ---------------------------------------------------------------------
+let healthData = null, graphData = null;
+let loadError = null;
+let simulation = null, svg = null, g = null, zoom = null;
+let animFrame3D = null;
+let loop3D = null;
+let activeFilters = {grain:true, entry:true, active:true, dormant:false};
 let weightThreshold = 0;
-let searchQuery = "";
-let selectedNodeId = null;
-let selectedEdgeKey = null;
+let searchQuery = '';
+let selectedNode = null, selectedEdge = null;
+let simulationPaused = false;
+let autoRefreshTimer = null;
+let isAutoRefresh = false;
 
-const fmt = new Intl.NumberFormat();
-const tooltip = document.getElementById("tooltip");
-
+// ── FETCH ─────────────────────────────────────────────────────────────────────
 function esc(value) {
-  return String(value ?? "").replace(/[&<>"']/g, ch => ({
-    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
   }[ch]));
 }
 
-function formatNumber(value, digits = 2) {
-  const n = Number(value ?? 0);
-  if (!Number.isFinite(n)) return "-";
-  return Number.isInteger(n) ? fmt.format(n) : n.toFixed(digits);
-}
-
-function formatRate(value) {
-  const n = Number(value ?? 0);
-  if (!Number.isFinite(n)) return "-";
-  return `${Math.round(n * 100)}%`;
-}
-
-function edgeKey(edge) {
-  const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
-  const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
-  return `${sid}->${tid}:${edge.edge_type || "earned"}:${edge.weight || 0}`;
-}
-
 async function fetchJSON(url) {
-  const response = await fetch(url, { cache: "no-store" });
+  const response = await fetch(url, { cache: 'no-store' });
   if (!response.ok) throw new Error(`${url} returned ${response.status}`);
   return response.json();
 }
 
 async function fetchAll() {
-  const error = document.getElementById("error-msg");
-  error.style.display = "none";
   try {
-    const [health, graph, events] = await Promise.all([
-      fetchJSON("/api/health"),
-      fetchJSON("/api/graph"),
-      fetchJSON("/api/events?limit=18").catch(() => ({ events: [] })),
+    const [h, gr] = await Promise.all([
+      fetchJSON('/api/health'),
+      fetchJSON('/api/graph'),
     ]);
-    healthData = health;
-    graphData = graph;
-    eventsData = events.events || [];
+    healthData = h;
+    graphData = gr;
+    loadError = null;
     renderHealth();
-    renderEvents();
     renderGraph();
+    document.getElementById('loading').style.display = 'none';
   } catch (err) {
-    console.error(err);
-    error.textContent = `Dashboard API unavailable: ${err.message}`;
-    error.style.display = "flex";
+    loadError = err;
+    console.error('Dashboard fetch failed', err);
+    document.getElementById('loading').style.display = 'none';
+    showLoadError(err.message || String(err));
   }
 }
 
+function showLoadError(message) {
+  const noData = document.getElementById('no-data-msg');
+  noData.style.display = 'flex';
+  noData.innerHTML = `<div style="color:var(--rose);font-weight:600">Unable to load Flux data</div><div style="font-size:11px;color:var(--text-dim);margin-top:6px">${esc(message)}</div>`;
+  document.getElementById('warnings-list').textContent = 'Flux API is unavailable.';
+  document.getElementById('health-table').textContent = 'No health data available.';
+}
+
+function toggleAutoRefresh() {
+  isAutoRefresh = !isAutoRefresh;
+  const btn = document.getElementById('autorefresh-btn');
+  const lbl = document.getElementById('refresh-interval');
+  btn.classList.toggle('active', isAutoRefresh);
+  lbl.style.display = isAutoRefresh ? '' : 'none';
+  if (isAutoRefresh) {
+    autoRefreshTimer = setInterval(() => { fetchAll(); }, 30000);
+  } else {
+    clearInterval(autoRefreshTimer);
+  }
+}
+
+// ── HEALTH RENDER ─────────────────────────────────────────────────────────────
 function renderHealth() {
   if (!healthData) return;
-  const status = healthData.status || "warning";
-  const badge = document.getElementById("status-badge");
-  const badgeStatus = ["healthy", "warning", "critical"].includes(status) ? status : "warning";
-  badge.className = `badge-${badgeStatus}`;
-  document.getElementById("status-text").textContent = status;
+  const h = healthData;
+  const status = ['healthy','warning','critical'].includes(h.status) ? h.status : 'warning';
 
-  const computedAt = healthData.computed_at ? new Date(healthData.computed_at) : null;
-  document.getElementById("computed-at").textContent =
-    computedAt && !Number.isNaN(computedAt.valueOf()) ? computedAt.toLocaleTimeString() : "not computed";
+  // Status badge
+  const badge = document.getElementById('status-badge');
+  const pulse = badge.querySelector('.pulse');
+  const statusText = document.getElementById('status-text');
+  badge.className = 'badge-' + status;
+  pulse.className = 'pulse pulse-' + (status==='healthy'?'green':status==='warning'?'amber':'rose');
+  statusText.textContent = status.toUpperCase();
 
-  const stats = graphData?.stats || {};
-  const signals = healthData.signals || {};
-  setMetric("m-grains", stats.grains, "value-cyan");
-  setMetric("m-entries", stats.entries, "");
-  setMetric("m-conduits", stats.conduits, stats.conduits > 0 ? "value-green" : "value-amber");
-  setMetric("m-embeddings", stats.embeddings, stats.embeddings > 0 ? "value-green" : "value-amber");
-  setMetric("m-retrieval", formatRate(signals.retrieval_success_rate?.value), "");
-  setMetric("m-fallback", formatRate(signals.fallback_trigger_rate?.value), (signals.fallback_trigger_rate?.value || 0) > 0.2 ? "value-rose" : "value-green");
+  // Computed at
+  const ca = h.computed_at ? new Date(h.computed_at) : null;
+  document.getElementById('computed-at').textContent = ca && !Number.isNaN(ca.valueOf()) ? ca.toLocaleTimeString() : '-';
 
-  const warnings = healthData.active_warnings || [];
-  document.getElementById("warnings-count").textContent = warnings.length;
-  const warningsList = document.getElementById("warnings-list");
-  warningsList.innerHTML = warnings.length ? warnings.map(w => `
-    <div class="warning-card">
-      <div class="warning-signal">${esc(w.signal)}</div>
-      <div class="warning-msg">${esc(w.suggestion)}</div>
-      <div class="warning-val">value ${esc(w.current_value)} / range ${esc(w.healthy_range)} / ${esc(w.severity)}</div>
-    </div>`).join("") : `<div class="empty-row">None</div>`;
+  // Metrics strip
+  const s = h.signals || {};
+  function pct(v) { return (v*100).toFixed(0) + '%'; }
+  const rs = s.retrieval_success_rate?.value ?? 0;
+  const fb = s.fallback_trigger_rate?.value ?? 0;
+  const fc = s.feedback_compliance_rate?.value ?? 0;
+  document.getElementById('m-retrieval').textContent = pct(rs);
+  document.getElementById('m-retrieval').className = 'm-value ' + (rs>=0.7?'c-green':'c-rose');
+  document.getElementById('m-fallback').textContent = pct(fb);
+  document.getElementById('m-fallback').className = 'm-value ' + (fb<0.3?'c-green':fb<0.7?'c-amber':'c-rose');
+  document.getElementById('m-feedback').textContent = pct(fc);
+  document.getElementById('m-feedback').className = 'm-value ' + (fc>=0.8?'c-green':'c-rose');
 
+  // Graph stats from graphData
+  if (graphData?.stats) {
+    const st = graphData.stats;
+    document.getElementById('m-grains').textContent = st.grains ?? '—';
+    document.getElementById('m-entries').textContent = st.entries ?? '—';
+    document.getElementById('m-conduits').textContent = st.conduits ?? '—';
+    document.getElementById('m-embed').textContent = st.embeddings ?? '—';
+  }
+
+  // Warnings
+  const warns = h.active_warnings || [];
+  document.getElementById('warn-count').textContent = warns.length;
+  document.getElementById('warn-count').className = 'rpanel-count' + (warns.length ? ' warn' : '');
+  const wl = document.getElementById('warnings-list');
+  if (!warns.length) {
+    wl.innerHTML = '<div style="color:var(--text-dim);font-size:11px">No active warnings</div>';
+  } else {
+    wl.innerHTML = warns.map(w => `
+      <div class="warning-card">
+        <div class="warning-signal">${esc(w.signal)}</div>
+        <div class="warning-msg">${esc(w.suggestion)}</div>
+        <div class="warning-val">Value: ${esc(w.current_value)} · Range: ${esc(w.healthy_range)} · Severity: ${esc(w.severity)}</div>
+      </div>`).join('');
+  }
+
+  // Health table
   const groups = {
-    "Retrieval": ["retrieval_success_rate", "avg_hops_per_retrieval", "fallback_trigger_rate"],
-    "Feedback": ["feedback_compliance_rate", "promotion_events", "shortcut_creation_rate"],
-    "Graph": ["highway_count", "highway_growth_rate", "orphan_rate", "core_grain_count", "avg_conduit_weight"],
-    "Decay": ["dormant_grain_rate", "conduit_dissolution_rate", "avg_weight_drop_on_failure"],
+    'Retrieval': ['retrieval_success_rate','avg_hops_per_retrieval','fallback_trigger_rate'],
+    'Feedback': ['feedback_compliance_rate','promotion_events'],
+    'Graph': ['highway_count','highway_growth_rate','orphan_rate','core_grain_count','avg_conduit_weight'],
+    'Decay': ['dormant_grain_rate','conduit_dissolution_rate','avg_weight_drop_on_failure','shortcut_creation_rate'],
   };
-  let healthHtml = "";
+  let html = '';
   for (const [group, keys] of Object.entries(groups)) {
-    healthHtml += `<div class="health-group"><div class="health-label">${group}</div>`;
-    for (const key of keys) {
-      const signal = signals[key];
-      if (!signal) continue;
-      const value = key.includes("rate") ? formatRate(signal.value) : formatNumber(signal.value);
-      healthHtml += `
-        <div class="health-row">
-          <span class="health-dot" style="background:${signal.healthy ? "var(--green)" : "var(--rose)"}"></span>
-          <span class="health-key" title="${esc(key)}">${esc(key.replaceAll("_", " "))}</span>
-          <span class="health-val" style="color:${signal.healthy ? "var(--text)" : "var(--rose)"}">${value}</span>
-        </div>`;
+    html += `<div class="health-group"><div class="health-group-label">${esc(group)}</div>`;
+    for (const k of keys) {
+      const sig = s[k]; if (!sig) continue;
+      const ok = sig.healthy;
+      const v = sig.value;
+      const display = (v > 0 && v <= 1 && k.includes('rate')) ? (v*100).toFixed(0)+'%' : v.toFixed ? v.toFixed(2) : v;
+      html += `<div class="health-row">
+        <div class="health-dot" style="background:${ok?'var(--green)':'var(--rose)'}"></div>
+        <div class="health-row-key">${esc(k.replace(/_/g,' '))}</div>
+        <div class="health-row-val" style="color:${ok?'var(--text)':'var(--rose)'}">${esc(display)}</div>
+      </div>`;
     }
-    healthHtml += `</div>`;
+    html += '</div>';
   }
-  document.getElementById("health-table").innerHTML = healthHtml;
+  document.getElementById('health-table').innerHTML = html;
 }
 
-function setMetric(id, value, tone) {
-  const el = document.getElementById(id);
-  el.className = `value ${tone || ""}`;
-  el.textContent = typeof value === "string" ? value : formatNumber(value, 0);
+// ── GRAPH RENDER ──────────────────────────────────────────────────────────────
+function nodeColor(n) {
+  if (n.status === 'dormant') return '#1e2d40';
+  if (n.node_type === 'entry') return '#7c3aed';
+  if (n.decay_class === 'core') return '#e0f2fe';
+  if (n.decay_class === 'ephemeral') return '#0e7490';
+  return '#22d3ee';
 }
-
-function renderEvents() {
-  const list = document.getElementById("events-list");
-  if (!eventsData.length) {
-    list.innerHTML = `<div class="empty-row">None</div>`;
-    return;
-  }
-  list.innerHTML = eventsData.map(e => {
-    const t = e.timestamp ? new Date(e.timestamp.replace("Z", "+00:00")) : null;
-    const time = t && !Number.isNaN(t.valueOf()) ? t.toLocaleTimeString() : "";
-    const detail = eventSummary(e.data || {});
-    return `<div class="event-card">
-      <div class="event-line"><span class="event-name">${esc(e.category)}/${esc(e.event)}</span><span class="event-time">${esc(time)}</span></div>
-      <div class="event-data">${esc(detail)}</div>
-    </div>`;
-  }).join("");
-}
-
-function eventSummary(data) {
-  const entries = Object.entries(data).filter(([k, v]) => v !== null && v !== undefined);
-  if (!entries.length) return "";
-  return entries.slice(0, 4).map(([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : v}`).join(" | ");
-}
-
-function nodeColor(node) {
-  if (node.status === "dormant") return "#263244";
-  if (node.node_type === "entry") return "#a78bfa";
-  if (node.decay_class === "core") return "#e0f2fe";
-  if (node.decay_class === "ephemeral") return "#0e7490";
-  return "#22d3ee";
-}
-
-function nodeRadius(node) {
-  if (node.node_type === "entry") return 6;
-  if (node.decay_class === "core") return 10;
+function nodeRadius(n) {
+  if (n.node_type === 'entry') return 6;
+  if (n.decay_class === 'core') return 10;
   return 8;
 }
-
-function edgeColor(edge) {
-  if (edge.direction === "bidirectional") return "#a78bfa";
-  if ((edge.effective_weight ?? edge.weight ?? 0) >= 0.55) return "#4ade80";
-  if (edge.decay_class === "core") return "#38bdf8";
-  return "#1e4a62";
+function edgeColor(l) {
+  if (l.direction === 'bidirectional') return '#a78bfa';
+  if (l.decay_class === 'core') return '#38bdf8';
+  if (l.decay_class === 'ephemeral') return '#1e3a4a';
+  return '#1e3f5a';
 }
 
 function getVisibleNodes() {
   if (!graphData) return [];
-  return (graphData.nodes || []).filter(node => {
-    const isEntry = node.node_type === "entry";
-    const typeOk = isEntry ? activeFilters.entry : activeFilters.grain;
-    const status = node.status || "active";
-    const statusOk = status === "dormant" ? activeFilters.dormant : activeFilters.active;
-    const haystack = `${node.label || ""} ${node.id || ""} ${node.feature || ""}`.toLowerCase();
-    const searchOk = !searchQuery || haystack.includes(searchQuery);
-    return typeOk && statusOk && searchOk;
+  return graphData.nodes.filter(n => {
+    const typeOk = (n.node_type === 'grain' && activeFilters.grain) || (n.node_type === 'entry' && activeFilters.entry);
+    const statusOk = (n.status === 'active' || !n.status) ? activeFilters.active : (n.status === 'dormant' ? activeFilters.dormant : true);
+    const label = String(n.label || '');
+    const searchOk = !searchQuery || label.toLowerCase().includes(searchQuery) || String(n.id || '').includes(searchQuery);
+    return typeOk && statusOk;
   });
 }
 
 function getVisibleLinks(nodeIds) {
   if (!graphData) return [];
-  const visible = new Set(nodeIds);
-  return (graphData.links || []).filter(link => {
-    const source = typeof link.source === "object" ? link.source.id : link.source;
-    const target = typeof link.target === "object" ? link.target.id : link.target;
-    const weight = Number(link.effective_weight ?? link.weight ?? 0);
-    return visible.has(source) && visible.has(target) && weight >= weightThreshold;
+  const idSet = new Set(nodeIds);
+  return graphData.links.filter(l => {
+    const sid = typeof l.source === 'object' ? l.source.id : l.source;
+    const tid = typeof l.target === 'object' ? l.target.id : l.target;
+    return idSet.has(sid) && idSet.has(tid) && (l.effective_weight ?? l.weight ?? 0) >= weightThreshold;
   });
 }
+
+
+// ── CANVAS STATE ─────────────────────────────────────────────────────────────
+let canvas = null, ctx = null;
+let canvasNodes = [], canvasLinks = [];
+let transform = d3.zoomIdentity;
+let hoveredNode = null, hoveredEdge = null;
+let dashOffset = 0;
+let nudgeTimer = null;
 
 function renderGraph() {
-  const container = document.getElementById("graph-container");
-  const error = document.getElementById("error-msg");
-  if (!window.d3) {
-    error.textContent = "Graph renderer unavailable: D3 did not load";
-    error.style.display = "flex";
-    return;
-  }
-
-  if (simulation) simulation.stop();
-  if (dashFrame) cancelAnimationFrame(dashFrame);
-
-  const width = Math.max(container.clientWidth, 360);
-  const height = Math.max(container.clientHeight, 360);
-  d3.select("#graph-svg").selectAll("*").remove();
-  svg = d3.select("#graph-svg").attr("width", width).attr("height", height);
+  const container = document.getElementById('graph-container');
+  const W = container.clientWidth, H = container.clientHeight;
 
   if (!graphData || !(graphData.nodes || []).length) {
-    document.getElementById("no-data-msg").style.display = "flex";
-    document.getElementById("gs-nodes").textContent = "0";
-    document.getElementById("gs-edges").textContent = "0";
+    document.getElementById('no-data-msg').style.display = 'flex';
     return;
   }
-  document.getElementById("no-data-msg").style.display = "none";
+  document.getElementById('no-data-msg').style.display = 'none';
 
-  const visibleNodes = getVisibleNodes();
-  const visibleLinks = getVisibleLinks(visibleNodes.map(n => n.id));
-  document.getElementById("gs-nodes").textContent = visibleNodes.length;
-  document.getElementById("gs-edges").textContent = visibleLinks.length;
+  const visNodes = getVisibleNodes();
+  const visLinks = getVisibleLinks(visNodes.map(n => n.id));
+  document.getElementById('gs-nodes').textContent = visNodes.length;
+  document.getElementById('gs-edges').textContent = visLinks.length;
 
-  const nodes = visibleNodes.map(n => ({ ...n }));
-  const nodeMap = new Map(nodes.map(n => [n.id, n]));
-  const links = visibleLinks.map(link => ({
-    ...link,
-    source: nodeMap.get(typeof link.source === "object" ? link.source.id : link.source),
-    target: nodeMap.get(typeof link.target === "object" ? link.target.id : link.target),
-  })).filter(link => link.source && link.target);
+  // Deep copy so D3 can mutate
+  canvasNodes = visNodes.map(n => ({...n}));
+  const nodeMap = new Map(canvasNodes.map(n => [n.id, n]));
+  assignPhases(canvasNodes);
+  canvasLinks = visLinks.map(l => ({
+    ...l,
+    source: nodeMap.get(typeof l.source==='object'?l.source.id:l.source) || (typeof l.source==='object'?l.source.id:l.source),
+    target: nodeMap.get(typeof l.target==='object'?l.target.id:l.target) || (typeof l.target==='object'?l.target.id:l.target),
+  })).filter(l => l.source && l.target && typeof l.source==='object' && typeof l.target==='object');
 
-  const defs = svg.append("defs");
-  ["forward", "bidirectional", "selected"].forEach(type => {
-    defs.append("marker")
-      .attr("id", `arrow-${type}`)
-      .attr("viewBox", "0 -4 8 8")
-      .attr("refX", 15)
-      .attr("refY", 0)
-      .attr("markerWidth", 6)
-      .attr("markerHeight", 6)
-      .attr("orient", "auto")
-      .append("path")
-      .attr("d", "M0,-4L8,0L0,4")
-      .attr("fill", type === "selected" ? "#22d3ee" : type === "bidirectional" ? "#a78bfa" : "#1e4a62");
-  });
+  // Set up canvas
+  canvas = document.getElementById('graph-canvas');
+  canvas.width = W; canvas.height = H;
+  ctx = canvas.getContext('2d');
 
-  zoomBehavior = d3.zoom().scaleExtent([0.12, 5]).on("zoom", event => graphLayer.attr("transform", event.transform));
-  svg.call(zoomBehavior);
-  graphLayer = svg.append("g");
+  // Cancel previous rAF
+  if (animFrame3D) { cancelAnimationFrame(animFrame3D); animFrame3D = null; }
+  if (nudgeTimer) { clearInterval(nudgeTimer); nudgeTimer = null; }
 
-  const linkSelection = graphLayer.append("g")
-    .attr("class", "links")
-    .selectAll("line")
-    .data(links, edgeKey)
-    .enter()
-    .append("line")
-    .attr("stroke", edgeColor)
-    .attr("stroke-width", d => Math.max(0.65, Number(d.effective_weight ?? d.weight ?? 0.25) * 3.2))
-    .attr("stroke-opacity", 0.72)
-    .attr("marker-end", d => `url(#arrow-${d.direction === "bidirectional" ? "bidirectional" : "forward"})`)
-    .attr("stroke-dasharray", d => d.direction === "bidirectional" ? "4 5" : d.decay_class === "core" ? "6 4" : null)
-    .style("cursor", "pointer")
-    .on("mouseenter", showEdgeTooltip)
-    .on("mousemove", moveTooltip)
-    .on("mouseleave", hideTooltip)
-    .on("click", (event, d) => { event.stopPropagation(); selectEdge(d); });
+  // D3 zoom on canvas
+  zoom = d3.zoom().scaleExtent([0.1, 5]).on('zoom', e => { transform = e.transform; });
+  d3.select(canvas).call(zoom);
 
-  const nodeSelection = graphLayer.append("g")
-    .attr("class", "nodes")
-    .selectAll("g")
-    .data(nodes, d => d.id)
-    .enter()
-    .append("g")
-    .attr("class", "graph-node")
-    .style("cursor", "pointer")
-    .call(d3.drag().on("start", dragStart).on("drag", dragged).on("end", dragEnd))
-    .on("mouseenter", showNodeTooltip)
-    .on("mousemove", moveTooltip)
-    .on("mouseleave", hideTooltip)
-    .on("click", (event, d) => { event.stopPropagation(); selectNode(d); });
+  // D3 drag on canvas via pointer events
+  canvas.onmousedown = onCanvasMouseDown;
+  canvas.onmousemove = onCanvasMouseMove;
+  canvas.onmouseup = onCanvasMouseUp;
+  canvas.onclick = onCanvasClick;
+  canvas.onmouseleave = () => { hideTooltip(); hoveredNode = null; hoveredEdge = null; };
 
-  nodeSelection.filter(d => d.decay_class === "core").append("circle")
-    .attr("r", d => nodeRadius(d) + 8)
-    .attr("fill", "#22d3ee")
-    .attr("fill-opacity", 0.08)
-    .attr("stroke", "#22d3ee")
-    .attr("stroke-opacity", 0.38)
-    .attr("stroke-width", 2);
+  // Force simulation
+  if (simulation) simulation.stop();
+  simulation = d3.forceSimulation(canvasNodes)
+    .force('link', d3.forceLink(canvasLinks).id(d=>d.id).distance(d => 60 + (1-(d.effective_weight??0.3))*60).strength(0.4))
+    .force('charge', d3.forceManyBody().strength(-180).distanceMax(300))
+    .force('center', d3.forceCenter(W/2, H/2))
+    .force('collision', d3.forceCollide(d => nodeRadius(d)+8))
+    .alphaDecay(0.015).alphaMin(0.001).alphaTarget(0.004)
+    .on('tick', draw);
 
-  nodeSelection.append("circle")
-    .attr("class", "node-main")
-    .attr("r", nodeRadius)
-    .attr("fill", nodeColor)
-    .attr("fill-opacity", d => d.status === "dormant" ? 0.38 : 0.92)
-    .attr("stroke", d => selectedNodeId === d.id ? "#22d3ee" : d.decay_class === "core" ? "#7dd3fc" : "transparent")
-    .attr("stroke-width", d => selectedNodeId === d.id ? 2.5 : 1.5);
-
-  nodeSelection.append("text")
-    .text(d => d.node_type === "entry" ? d.label : truncate(d.label || d.id, 24))
-    .attr("x", d => nodeRadius(d) + 5)
-    .attr("y", 4)
-    .attr("fill", "#8d99ad")
-    .attr("font-size", "9px")
-    .attr("font-family", "JetBrains Mono, Consolas, monospace")
-    .attr("pointer-events", "none");
-
-  simulation = d3.forceSimulation(nodes)
-    .force("link", d3.forceLink(links).id(d => d.id).distance(d => 58 + (1 - Number(d.effective_weight ?? 0.3)) * 74).strength(0.42))
-    .force("charge", d3.forceManyBody().strength(-175).distanceMax(320))
-    .force("center", d3.forceCenter(width / 2, height / 2))
-    .force("collision", d3.forceCollide(d => nodeRadius(d) + 10))
-    .alphaDecay(0.018)
-    .alphaMin(0.001)
-    .on("tick", () => {
-      linkSelection
-        .attr("x1", d => d.source.x)
-        .attr("y1", d => d.source.y)
-        .attr("x2", d => d.target.x)
-        .attr("y2", d => d.target.y);
-      nodeSelection.attr("transform", d => `translate(${d.x},${d.y})`);
-    });
-
-  animateDashes(linkSelection);
-  nodeSelectionGlobal = nodeSelection;
-  linkSelectionGlobal = linkSelection;
-  svg.on("click", () => clearSelection());
-  if (simulationPaused) simulation.stop();
-}
-
-function animateDashes(linkSelection) {
-  function loop() {
-    dashOffset -= 0.35;
-    linkSelection.attr("stroke-dashoffset", dashOffset);
-    dashFrame = requestAnimationFrame(loop);
-  }
-  loop();
-}
-
-function dragStart(event, d) {
-  if (!event.active && simulation && !simulationPaused) simulation.alphaTarget(0.25).restart();
-  d.fx = d.x;
-  d.fy = d.y;
-}
-function dragged(event, d) {
-  d.fx = event.x;
-  d.fy = event.y;
-}
-function dragEnd(event, d) {
-  if (!event.active && simulation && !simulationPaused) simulation.alphaTarget(0.015);
-  d.fx = null;
-  d.fy = null;
-}
-
-function showTooltip(event, title, rows) {
-  document.getElementById("tt-title").textContent = title;
-  document.getElementById("tt-body").innerHTML = rows.map(([key, value]) =>
-    `<div class="tt-row"><span class="tt-key">${esc(key)}</span><span class="tt-val">${esc(value)}</span></div>`
-  ).join("");
-  tooltip.style.opacity = "1";
-  positionTooltip(event.clientX, event.clientY);
-}
-function positionTooltip(x, y) {
-  const rect = tooltip.getBoundingClientRect();
-  tooltip.style.left = `${x + 14 + rect.width > window.innerWidth ? x - rect.width - 12 : x + 14}px`;
-  tooltip.style.top = `${Math.min(y - 10, window.innerHeight - rect.height - 10)}px`;
-}
-function moveTooltip(event) { positionTooltip(event.clientX, event.clientY); }
-function hideTooltip() { tooltip.style.opacity = "0"; }
-function showNodeTooltip(event, node) {
-  showTooltip(event, truncate(node.label || node.id, 72), [
-    ["type", node.node_type],
-    ["status", node.status || "-"],
-    ["decay", node.decay_class || "-"],
-    ["provenance", node.provenance || "-"],
-    ["context", node.context_spread ?? "-"],
-  ]);
-}
-function showEdgeTooltip(event, edge) {
-  const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
-  const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
-  showTooltip(event, `${sid.slice(0, 8)} -> ${tid.slice(0, 8)}`, [
-    ["weight", formatNumber(edge.weight, 4)],
-    ["effective", formatNumber(edge.effective_weight, 4)],
-    ["direction", edge.direction || "-"],
-    ["decay", edge.decay_class || "-"],
-    ["uses", edge.use_count ?? 0],
-  ]);
-}
-
-function selectNode(node) {
-  selectedNodeId = node.id;
-  selectedEdgeKey = null;
-  const neighbors = new Set([node.id]);
-  linkSelectionGlobal?.each(function(edge) {
-    if (!edge || !edge.source || !edge.target) return;
-    const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
-    const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
-    if (sid === node.id || tid === node.id) {
-      neighbors.add(sid);
-      neighbors.add(tid);
+  // Gentle nudge every 5s
+  nudgeTimer = setInterval(() => {
+    if (simulation && !simulationPaused) {
+      canvasNodes.forEach(n => {
+        n.vx = (n.vx||0) + (Math.random()-0.5)*0.18;
+        n.vy = (n.vy||0) + (Math.random()-0.5)*0.18;
+      });
+      simulation.alphaTarget(0.004).restart();
     }
-  });
-  nodeSelectionGlobal?.attr("opacity", d => neighbors.has(d.id) ? 1 : 0.16);
-  linkSelectionGlobal?.attr("stroke-opacity", edge => {
-    if (!edge || !edge.source || !edge.target) return 0.72;
-    const sid = typeof edge.source === "object" ? edge.source.id : edge.source;
-    const tid = typeof edge.target === "object" ? edge.target.id : edge.target;
-    return sid === node.id || tid === node.id ? 1 : 0.06;
-  });
-  nodeSelectionGlobal?.select("circle.node-main")
-    .attr("stroke", d => d.id === node.id ? "#22d3ee" : d.decay_class === "core" ? "#7dd3fc" : "transparent")
-    .attr("stroke-width", d => d.id === node.id ? 2.5 : 1.5);
-  renderInspector(node, "node");
+  }, 5000);
+
+  // Dash animation rAF
+  loop3D = function() {
+    animFrame3D = requestAnimationFrame(loop3D);
+    dashOffset -= 0.5;
+    draw();
+  };
+  loop3D();
+
+  if (simulationPaused) { simulation.alphaTarget(0).stop(); }
 }
 
-function selectEdge(edge) {
-  selectedEdgeKey = edgeKey(edge);
-  selectedNodeId = null;
-  nodeSelectionGlobal?.attr("opacity", 0.25);
-  linkSelectionGlobal?.attr("stroke-opacity", e => edgeKey(e) === selectedEdgeKey ? 1 : 0.08);
-  renderInspector(edge, "edge");
+// ── CANVAS DRAW ───────────────────────────────────────────────────────────────
+function draw() {
+  if (!ctx || !canvas) return;
+  const W = canvas.width, H = canvas.height;
+  ctx.clearRect(0, 0, W, H);
+  ctx.save();
+  ctx.translate(transform.x, transform.y);
+  ctx.scale(transform.k, transform.k);
+
+  const t = performance.now() / 1000;
+
+  // Draw edges
+  for (const l of canvasLinks) {
+    const sx = l.source.x, sy = l.source.y;
+    const tx = l.target.x, ty = l.target.y;
+    if (sx==null||sy==null||tx==null||ty==null) continue;
+
+    const isSelected = selectedEdge === l;
+    const isHovered = hoveredEdge === l;
+    const isDimmed = (selectedNode && l.source !== selectedNode && l.target !== selectedNode);
+
+    const w = Math.max(0.5, (l.effective_weight??0.3)*2.5);
+    let alpha = isDimmed ? 0.04 : (isSelected||isHovered) ? 1 : 0.55;
+
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = isSelected ? '#22d3ee' : edgeColor(l);
+    ctx.lineWidth = isSelected ? w+1 : w;
+
+    // Dashed flow for core/bidirectional
+    if (l.decay_class==='core' || l.direction==='bidirectional') {
+      ctx.setLineDash([6, 4]);
+      ctx.lineDashOffset = dashOffset;
+    } else {
+      ctx.setLineDash([]);
+    }
+
+    ctx.beginPath();
+    ctx.moveTo(sx, sy);
+    ctx.lineTo(tx, ty);
+    ctx.stroke();
+
+    // Arrowhead
+    const angle = Math.atan2(ty-sy, tx-sx);
+    const r = nodeRadius(l.target)+3;
+    const ax = tx - r*Math.cos(angle), ay = ty - r*Math.sin(angle);
+    ctx.setLineDash([]);
+    ctx.fillStyle = isSelected ? '#22d3ee' : edgeColor(l);
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(ax - 8*Math.cos(angle-0.4), ay - 8*Math.sin(angle-0.4));
+    ctx.lineTo(ax - 8*Math.cos(angle+0.4), ay - 8*Math.sin(angle+0.4));
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  }
+
+  // Draw nodes
+  for (const n of canvasNodes) {
+    if (n.x==null||n.y==null) continue;
+    const r = nodeRadius(n);
+    const isSelected = selectedNode === n;
+    const isHovered = hoveredNode === n;
+    const isDimmed = (selectedNode && selectedNode !== n && !isNeighbor(selectedNode, n));
+    const alpha = isDimmed ? 0.1 : 1;
+    const dormant = n.status === 'dormant';
+
+    ctx.save();
+    ctx.globalAlpha = alpha;
+
+    // Glow for core grains
+    if (n.decay_class === 'core' && !dormant) {
+      const glowR = r + 7 + Math.sin(t * 2.2 + n._phase) * 3;
+      const grad = ctx.createRadialGradient(n.x, n.y, r*0.5, n.x, n.y, glowR+4);
+      grad.addColorStop(0, 'rgba(34,211,238,0.25)');
+      grad.addColorStop(1, 'rgba(34,211,238,0)');
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, glowR+4, 0, Math.PI*2);
+      ctx.fillStyle = grad;
+      ctx.fill();
+    }
+
+    // Selection ring
+    if (isSelected || isHovered) {
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, r + 4, 0, Math.PI*2);
+      ctx.strokeStyle = isSelected ? '#22d3ee' : 'rgba(34,211,238,0.4)';
+      ctx.lineWidth = isSelected ? 2 : 1;
+      ctx.stroke();
+    }
+
+    // Breathing radius for working/core grains
+    let br = r;
+    if (!dormant && n.node_type==='grain') {
+      const speed = n.decay_class==='core' ? 2.2 : 1.8;
+      br = r + Math.sin(t * speed + (n._phase||0)) * (n.decay_class==='core'?1.5:0.8);
+    }
+
+    // Node fill
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, br, 0, Math.PI*2);
+    ctx.fillStyle = nodeColor(n);
+    ctx.globalAlpha = alpha * (dormant ? 0.35 : 0.9);
+    ctx.fill();
+
+    // Core stroke ring
+    if (n.decay_class==='core') {
+      ctx.strokeStyle = '#7dd3fc';
+      ctx.lineWidth = 1.5;
+      ctx.globalAlpha = alpha * 0.7;
+      ctx.stroke();
+    }
+
+    ctx.globalAlpha = alpha;
+
+    // Label
+    const label = n.node_type==='entry' ? n.label : n.label.slice(0,22)+(n.label.length>22?'…':'');
+    ctx.fillStyle = isSelected ? '#dde3f0' : '#5a6480';
+    ctx.font = '9px JetBrains Mono, monospace';
+    ctx.fillText(label, n.x + br + 4, n.y + 3.5);
+
+    ctx.restore();
+  }
+
+  ctx.restore();
 }
 
-function clearSelection() {
-  selectedNodeId = null;
-  selectedEdgeKey = null;
-  nodeSelectionGlobal?.attr("opacity", 1);
-  linkSelectionGlobal?.attr("stroke-opacity", 0.72);
-  nodeSelectionGlobal?.select("circle.node-main")
-    .attr("stroke", d => d.decay_class === "core" ? "#7dd3fc" : "transparent")
-    .attr("stroke-width", 1.5);
-  document.getElementById("inspector-empty").style.display = "";
-  document.getElementById("inspector-content").style.display = "none";
+// Assign stable phase offsets to nodes
+function assignPhases(nodes) {
+  nodes.forEach((n,i) => { n._phase = i * 0.61803 * Math.PI * 2; });
 }
 
-function tag(value) {
-  const v = String(value ?? "-");
-  const cls = v === "entry" ? "violet" : v === "core" || v === "active" ? "cyan" : v === "dormant" ? "rose" : v === "bidirectional" ? "violet" : "dim";
-  return `<span class="tag tag-${cls}">${esc(v)}</span>`;
+function isNeighbor(a, b) {
+  for (const l of canvasLinks) {
+    if ((l.source===a && l.target===b) || (l.target===a && l.source===b)) return true;
+  }
+  return false;
 }
 
-function renderInspector(item, type) {
-  document.getElementById("inspector-empty").style.display = "none";
-  const container = document.getElementById("inspector-content");
-  container.style.display = "";
-  if (type === "node") {
-    const color = nodeColor(item);
-    container.innerHTML = `
-      <div class="node-head">
-        <div class="node-icon" style="background:${color}22;border:1px solid ${color}55">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="${color}"><circle cx="12" cy="12" r="${item.node_type === "entry" ? 6 : 8}"/></svg>
-        </div>
-        <div>
-          <div class="node-label">${esc(item.label || item.id)}</div>
-          <div class="node-type">${esc(item.node_type)}${item.decay_class ? " / " + esc(item.decay_class) : ""}</div>
-        </div>
-      </div>
-      <div class="kv">
-        ${kv("ID", item.id)}
-        ${kv("Type", tag(item.node_type), true)}
-        ${item.status ? kv("Status", tag(item.status), true) : ""}
-        ${item.decay_class ? kv("Decay", tag(item.decay_class), true) : ""}
-        ${item.provenance ? kv("Provenance", tag(item.provenance), true) : ""}
-        ${item.context_spread !== undefined ? kv("Context", item.context_spread) : ""}
-        ${item.feature ? kv("Feature", item.feature) : ""}
-      </div>`;
-  } else {
-    const sid = typeof item.source === "object" ? item.source.id : item.source;
-    const tid = typeof item.target === "object" ? item.target.id : item.target;
-    const sourceLabel = typeof item.source === "object" ? item.source.label : sid;
-    const targetLabel = typeof item.target === "object" ? item.target.label : tid;
-    container.innerHTML = `
-      <div class="node-label" style="margin-bottom:10px">${esc(truncate(sourceLabel || sid, 46))}<br><span style="color:var(--dim)">to</span><br>${esc(truncate(targetLabel || tid, 46))}</div>
-      <div class="kv">
-        ${kv("Weight", formatNumber(item.weight, 4))}
-        ${kv("Effective", formatNumber(item.effective_weight, 4))}
-        ${kv("Direction", tag(item.direction || "forward"), true)}
-        ${kv("Decay", tag(item.decay_class || "working"), true)}
-        ${kv("Use count", item.use_count ?? 0)}
-        ${kv("Edge type", tag(item.edge_type || "earned"), true)}
-      </div>`;
+// ── CANVAS HIT DETECTION ──────────────────────────────────────────────────────
+function canvasPoint(e) {
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX - rect.left - transform.x) / transform.k;
+  const my = (e.clientY - rect.top  - transform.y) / transform.k;
+  return [mx, my];
+}
+
+function hitNode(mx, my) {
+  for (let i = canvasNodes.length-1; i >= 0; i--) {
+    const n = canvasNodes[i];
+    const dx = (n.x||0)-mx, dy = (n.y||0)-my;
+    if (Math.sqrt(dx*dx+dy*dy) <= nodeRadius(n)+4) return n;
+  }
+  return null;
+}
+
+function hitEdge(mx, my) {
+  const THRESH = 5 / transform.k;
+  for (const l of canvasLinks) {
+    const sx=l.source.x, sy=l.source.y, tx=l.target.x, ty=l.target.y;
+    if (sx==null) continue;
+    const dx=tx-sx, dy=ty-sy, len=Math.sqrt(dx*dx+dy*dy);
+    if (len<1) continue;
+    const t2 = Math.max(0,Math.min(1,((mx-sx)*dx+(my-sy)*dy)/(len*len)));
+    const px=sx+t2*dx-mx, py=sy+t2*dy-my;
+    if (Math.sqrt(px*px+py*py)<=THRESH) return l;
+  }
+  return null;
+}
+
+// ── CANVAS MOUSE EVENTS ───────────────────────────────────────────────────────
+let _dragging = null, _dragMoved = false;
+
+function onCanvasMouseDown(e) {
+  if (e.button !== 0) return;
+  const [mx, my] = canvasPoint(e);
+  const n = hitNode(mx, my);
+  if (n) {
+    _dragging = n; _dragMoved = false;
+    if (!simulation._active) simulation.alphaTarget(0.3).restart();
+    n.fx = n.x; n.fy = n.y;
+    // Stop zoom from panning while dragging node
+    d3.select(canvas).on('.zoom', null);
   }
 }
 
-function kv(key, value, raw = false) {
-  return `<div class="kv-row"><span class="kv-key">${esc(key)}</span><span class="kv-val">${raw ? value : esc(value)}</span></div>`;
+function onCanvasMouseMove(e) {
+  const [mx, my] = canvasPoint(e);
+  if (_dragging) {
+    _dragMoved = true;
+    _dragging.fx = mx; _dragging.fy = my;
+    simulation.alphaTarget(0.15).restart();
+    return;
+  }
+  const n = hitNode(mx, my);
+  if (n) {
+    hoveredNode = n; hoveredEdge = null;
+    canvas.style.cursor = 'pointer';
+    showNodeTooltip(e, n);
+  } else {
+    const l = hitEdge(mx, my);
+    hoveredEdge = l; hoveredNode = null;
+    canvas.style.cursor = l ? 'pointer' : 'default';
+    if (l) showEdgeTooltip(e, l); else hideTooltip();
+  }
 }
 
-function truncate(value, max) {
-  const text = String(value ?? "");
-  return text.length > max ? `${text.slice(0, max - 1)}...` : text;
+function onCanvasMouseUp(e) {
+  if (_dragging) {
+    _dragging.fx = null; _dragging.fy = null;
+    simulation.alphaTarget(0.004);
+    _dragging = null;
+    // Restore zoom
+    d3.select(canvas).call(zoom);
+  }
 }
 
-function toggleFilter(key) {
-  activeFilters[key] = !activeFilters[key];
-  document.getElementById(`f-${key}`).classList.toggle("active", activeFilters[key]);
-  clearSelection();
-  renderGraph();
+function onCanvasClick(e) {
+  if (_dragMoved) { _dragMoved = false; return; }
+  const [mx, my] = canvasPoint(e);
+  const n = hitNode(mx, my);
+  if (n) { selectNode(n); return; }
+  const l = hitEdge(mx, my);
+  if (l) { selectEdge(l); return; }
+  deselectAll();
 }
 
-function onSearch(value) {
-  searchQuery = value.toLowerCase().trim();
-  renderGraph();
-}
-
-function onWeightChange(value) {
-  weightThreshold = Number(value);
-  document.getElementById("weight-val").textContent = weightThreshold.toFixed(2);
-  clearSelection();
-  renderGraph();
-}
+function dragStart() {}
+function dragged() {}
+function dragEnd() {}
 
 function toggleSimulation() {
   simulationPaused = !simulationPaused;
-  document.getElementById("pause-btn").classList.toggle("active", simulationPaused);
-  const icon = document.getElementById("pause-icon");
+  const icon = document.getElementById('pause-icon');
   if (simulationPaused) {
-    simulation?.stop();
-    if (dashFrame) cancelAnimationFrame(dashFrame);
-    dashFrame = null;
-    icon.innerHTML = `<polygon points="5 3 19 12 5 21 5 3"/>`;
+    simulation?.alphaTarget(0).stop();
+    cancelAnimationFrame(animFrame3D); animFrame3D = null;
+    icon.innerHTML = '<polygon points="5 3 19 12 5 21 5 3"/>';
   } else {
-    simulation?.alphaTarget(0.025).restart();
-    icon.innerHTML = `<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>`;
-    renderGraph();
+    simulation?.alphaTarget(0.004).restart();
+    if (loop3D && !animFrame3D) loop3D();
+    icon.innerHTML = '<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>';
   }
 }
 
 function resetView() {
-  if (!svg || !zoomBehavior) return;
-  svg.transition().duration(450).call(zoomBehavior.transform, d3.zoomIdentity);
+  if (!canvas || !zoom) return;
+  d3.select(canvas).transition().duration(500).call(zoom.transform, d3.zoomIdentity);
 }
 
-function toggleAutoRefresh() {
-  const btn = document.getElementById("autorefresh-btn");
-  if (autoRefreshTimer) {
-    clearInterval(autoRefreshTimer);
-    autoRefreshTimer = null;
-    btn.classList.remove("active");
+// ── TOOLTIP ───────────────────────────────────────────────────────────────────
+const tt = document.getElementById('tooltip');
+function showTooltip(x, y, title, rows) {
+  document.getElementById('tt-title').textContent = title;
+  document.getElementById('tt-body').innerHTML = rows.map(([k,v])=>
+    `<div class="tt-row"><span class="tt-key">${esc(k)}</span><span class="tt-val">${esc(v)}</span></div>`
+  ).join('');
+  tt.style.opacity = '1';
+  positionTooltip(x, y);
+}
+function positionTooltip(x, y) {
+  const r = tt.getBoundingClientRect();
+  tt.style.left = (x + 14 + r.width > window.innerWidth ? x - r.width - 10 : x + 14) + 'px';
+  tt.style.top = Math.min(y - 10, window.innerHeight - r.height - 10) + 'px';
+}
+function moveTooltip(event) { positionTooltip(event.clientX, event.clientY); }
+function hideTooltip() { tt.style.opacity = '0'; }
+function showNodeTooltip(event, d) {
+  showTooltip(event.clientX, event.clientY, String(d.label || d.id || '').slice(0,60), [
+    ['type', d.node_type],
+    ...(d.decay_class ? [['decay', d.decay_class]] : []),
+    ...(d.status ? [['status', d.status]] : []),
+    ...(d.provenance ? [['provenance', d.provenance]] : []),
+    ...(d.context_spread !== undefined ? [['ctx spread', d.context_spread]] : []),
+  ]);
+}
+function showEdgeTooltip(event, d) {
+  const sid = typeof d.source==='object'?d.source.id:d.source;
+  const tid = typeof d.target==='object'?d.target.id:d.target;
+  showTooltip(event.clientX, event.clientY, `${sid.slice(0,10)}… → ${tid.slice(0,10)}…`, [
+    ['weight', (d.weight??0).toFixed(4)],
+    ['eff. weight', (d.effective_weight??0).toFixed(4)],
+    ['direction', d.direction],
+    ['decay', d.decay_class??'—'],
+    ['use count', d.use_count??0],
+    ['edge type', d.edge_type??'—'],
+  ]);
+}
+
+// ── SELECTION / INSPECTOR ─────────────────────────────────────────────────────
+function deselectAll() {
+  selectedNode = null; selectedEdge = null;
+  document.getElementById('inspector-empty').style.display = '';
+  document.getElementById('inspector-content').style.display = 'none';
+}
+
+function selectNode(d) {
+  selectedNode = d; selectedEdge = null;
+  renderInspector(d, 'node');
+}
+
+function selectEdge(d) {
+  selectedEdge = d; selectedNode = null;
+  renderInspector(d, 'edge');
+}
+
+function tagHtml(v, positive) {
+  const cls = v==='active'||v==='core'?'cyan':v==='entry'?'violet':v==='dormant'||positive===false?'rose':v==='working'?'cyan':v==='ephemeral'?'dim':'dim';
+  return `<span class="tag tag-${cls}">${esc(v)}</span>`;
+}
+
+function renderInspector(d, type) {
+  document.getElementById('inspector-empty').style.display = 'none';
+  const el = document.getElementById('inspector-content');
+  el.style.display = '';
+  if (type === 'node') {
+    const color = nodeColor(d);
+    const isEntry = d.node_type==='entry';
+    el.innerHTML = `
+      <div class="inspector-node-header">
+        <div class="inspector-icon" style="background:${color}22;border:1px solid ${color}44">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="${color}"><circle cx="12" cy="12" r="${isEntry?6:8}"/></svg>
+        </div>
+        <div>
+          <div class="inspector-label">${esc(d.label || d.id)}</div>
+          <div class="inspector-type">${esc(d.node_type)}${d.decay_class?' · '+esc(d.decay_class):''}</div>
+        </div>
+      </div>
+      <div class="inspector-rows">
+        <div class="inspector-row"><span class="ir-key">ID</span><span class="ir-val" style="font-size:10px">${esc(d.id)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Type</span><span class="ir-val">${tagHtml(d.node_type)}</span></div>
+        ${d.status?`<div class="inspector-row"><span class="ir-key">Status</span><span class="ir-val">${tagHtml(d.status)}</span></div>`:''}
+        ${d.decay_class?`<div class="inspector-row"><span class="ir-key">Decay class</span><span class="ir-val">${tagHtml(d.decay_class)}</span></div>`:''}
+        ${d.provenance?`<div class="inspector-row"><span class="ir-key">Provenance</span><span class="ir-val"><span class="tag tag-dim">${esc(d.provenance)}</span></span></div>`:''}
+        ${d.context_spread!==undefined?`<div class="inspector-row"><span class="ir-key">Context spread</span><span class="ir-val">${esc(d.context_spread)}</span></div>`:''}
+        ${d.feature?`<div class="inspector-row"><span class="ir-key">Feature</span><span class="ir-val">${esc(d.feature)}</span></div>`:''}
+      </div>`;
   } else {
-    autoRefreshTimer = setInterval(fetchAll, 30000);
-    btn.classList.add("active");
+    const sid = typeof d.source==='object'?d.source.id:d.source;
+    const tid = typeof d.target==='object'?d.target.id:d.target;
+    const sl = typeof d.source==='object'?d.source.label:sid;
+    const tl = typeof d.target==='object'?d.target.label:tid;
+    el.innerHTML = `
+      <div style="margin-bottom:10px">
+        <div class="inspector-label" style="font-size:11px">${esc(String(sl||sid).slice(0,40))}…</div>
+        <div style="color:var(--text-dim);font-size:10px;margin:3px 0">↓</div>
+        <div class="inspector-label" style="font-size:11px">${esc(String(tl||tid).slice(0,40))}…</div>
+      </div>
+      <div class="inspector-rows">
+        <div class="inspector-row"><span class="ir-key">Weight</span><span class="ir-val">${(d.weight??0).toFixed(4)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Eff. weight</span><span class="ir-val">${(d.effective_weight??0).toFixed(4)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Direction</span><span class="ir-val">${tagHtml(d.direction)}</span></div>
+        <div class="inspector-row"><span class="ir-key">Decay class</span><span class="ir-val">${tagHtml(d.decay_class??'working')}</span></div>
+        <div class="inspector-row"><span class="ir-key">Use count</span><span class="ir-val">${d.use_count??0}</span></div>
+        <div class="inspector-row"><span class="ir-key">Edge type</span><span class="ir-val"><span class="tag tag-dim">${esc(d.edge_type??'earned')}</span></span></div>
+      </div>`;
   }
 }
 
-function toggleSection(id) {
-  const body = document.getElementById(`body-${id}`);
-  const chev = document.getElementById(`chev-${id}`);
-  const open = body.style.display === "none";
-  body.style.display = open ? "" : "none";
-  chev?.classList.toggle("open", open);
+// ── FILTERS / SEARCH ──────────────────────────────────────────────────────────
+function toggleFilter(key) {
+  activeFilters[key] = !activeFilters[key];
+  const btn = document.getElementById('f-'+key);
+  if (btn) btn.classList.toggle('active', activeFilters[key]);
+  renderGraph();
+}
+function onSearch(val) {
+  searchQuery = val.toLowerCase().trim();
+  renderGraph();
+}
+function onWeightChange(val) {
+  weightThreshold = parseFloat(val);
+  document.getElementById('weight-val').textContent = parseFloat(val).toFixed(2);
+  renderGraph();
 }
 
-document.getElementById("refresh-btn").addEventListener("click", fetchAll);
-document.getElementById("autorefresh-btn").addEventListener("click", toggleAutoRefresh);
-document.getElementById("pause-btn").addEventListener("click", toggleSimulation);
-document.getElementById("reset-btn").addEventListener("click", resetView);
-document.getElementById("search-input").addEventListener("input", event => onSearch(event.target.value));
-document.getElementById("weight-slider").addEventListener("input", event => onWeightChange(event.target.value));
-["grain", "entry", "active", "dormant"].forEach(key => {
-  document.getElementById(`f-${key}`).addEventListener("click", () => toggleFilter(key));
+// ── PANEL COLLAPSE ────────────────────────────────────────────────────────────
+function toggleSection(id) {
+  const body = document.getElementById('body-'+id);
+  const chev = document.getElementById('chev-'+id);
+  const visible = body.style.display !== 'none';
+  body.style.display = visible ? 'none' : '';
+  if (chev) chev.classList.toggle('open', !visible);
+}
+
+// ── INIT ──────────────────────────────────────────────────────────────────────
+window.addEventListener('load', () => {
+  fetchAll();
+  window.addEventListener('resize', () => { if (graphData) renderGraph(); });
 });
-document.querySelectorAll(".r-header").forEach(header => {
-  header.addEventListener("click", () => toggleSection(header.dataset.section));
-});
-window.addEventListener("resize", () => { if (graphData) renderGraph(); });
-window.addEventListener("load", fetchAll);
 </script>
-</body>
-</html>
-"""
+
+
+</body></html>"""
 
 
 def _recent_events(store: Any, limit: int = 25) -> dict[str, list[dict[str, Any]]]:

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -149,6 +149,25 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
   }
   .legend-item { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-muted); }
   .legend-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .legend-line { width: 22px; border-radius: 999px; background: var(--cyan); flex-shrink: 0; }
+  .legend-line.weak { height: 1px; opacity: 0.35; }
+  .legend-line.strong { height: 4px; box-shadow: 0 0 10px rgba(34,211,238,0.35); }
+  #activity-indicator {
+    position: absolute; top: 10px; left: 10px;
+    display: flex; align-items: center; gap: 7px;
+    background: rgba(15,17,23,0.8); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 5px 9px; font-size: 10px;
+    font-family: var(--font-mono); color: var(--text-muted);
+    backdrop-filter: blur(4px); pointer-events: none;
+  }
+  #activity-indicator.live { color: var(--cyan); border-color: rgba(34,211,238,0.35); }
+  .activity-dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--text-dim); box-shadow: 0 0 0 rgba(34,211,238,0);
+  }
+  #activity-indicator.live .activity-dot {
+    background: var(--cyan); box-shadow: 0 0 14px rgba(34,211,238,0.7);
+  }
   #tooltip {
     position: fixed; pointer-events: none; z-index: 999;
     background: var(--surface); border: 1px solid var(--border2);
@@ -329,6 +348,10 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
       bottom: calc(76px + env(safe-area-inset-bottom, 0px));
       border-radius: 10px; background: rgba(8,10,14,0.72);
     }
+    #activity-indicator {
+      top: 58px; left: 10px; right: auto;
+      border-radius: 10px; background: rgba(8,10,14,0.72);
+    }
     #tooltip { display: none; }
 
     #right-panel {
@@ -491,11 +514,14 @@ _DASHBOARD_HTML = r"""<!DOCTYPE html><html lang="en"><head>
       <div id="graph-container">
         <canvas id="graph-canvas" style="width:100%;height:100%;display:block;"></canvas>
         <div id="graph-stats">nodes: <span id="gs-nodes">0</span> · edges: <span id="gs-edges">0</span></div>
+        <div id="activity-indicator"><span class="activity-dot"></span><span id="activity-text">watching events</span></div>
         <div id="graph-overlay">
           <div class="legend-item"><div class="legend-dot" style="background:#22d3ee"></div>Grain (working)</div>
           <div class="legend-item"><div class="legend-dot" style="background:#e0f2fe"></div>Grain (core)</div>
           <div class="legend-item"><div class="legend-dot" style="background:#a78bfa"></div>Entry</div>
           <div class="legend-item"><div class="legend-dot" style="background:#334155"></div>Dormant</div>
+          <div class="legend-item"><div class="legend-line weak"></div>Weak conduit</div>
+          <div class="legend-item"><div class="legend-line strong"></div>Strong conduit</div>
         </div>
         <div id="no-data-msg" style="display: none;">
           <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.4"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12" stroke-opacity="0.7"></line><line x1="12" y1="16" x2="12.01" y2="16" stroke-opacity="0.7"></line></svg>
@@ -743,11 +769,26 @@ function nodeRadius(n) {
   if (n.decay_class === 'core') return 10;
   return 8;
 }
+function clamp01(v) { return Math.max(0, Math.min(1, v)); }
+function edgeWeight(l) {
+  const v = Number(l.effective_weight ?? l.weight ?? 0);
+  return Number.isFinite(v) ? Math.max(0, v) : 0;
+}
+function edgeStrength(l) {
+  return clamp01(l._strength ?? Math.sqrt(Math.min(1, edgeWeight(l))));
+}
 function edgeColor(l) {
-  if (l.direction === 'bidirectional') return '#a78bfa';
-  if (l.decay_class === 'core') return '#38bdf8';
-  if (l.decay_class === 'ephemeral') return '#1e3a4a';
-  return '#1e3f5a';
+  const s = edgeStrength(l);
+  if (l.direction === 'bidirectional') return d3.interpolateRgb('#2b2544', '#a78bfa')(s);
+  if (l.decay_class === 'core') return d3.interpolateRgb('#1d3a52', '#7dd3fc')(s);
+  if (l.decay_class === 'ephemeral') return d3.interpolateRgb('#17202b', '#0e7490')(s);
+  return d3.interpolateRgb('#1b2634', '#22d3ee')(s);
+}
+function edgeWidth(l) {
+  return 0.45 + Math.pow(edgeStrength(l), 1.35) * 4.2;
+}
+function edgeAlpha(l) {
+  return 0.16 + edgeStrength(l) * 0.64;
 }
 
 function nodePassesFilters(n) {
@@ -794,6 +835,207 @@ let dashOffset = 0;
 let nudgeTimer = null;
 let searchMatchIds = new Set();
 let canvasCssWidth = 0, canvasCssHeight = 0, canvasDpr = 1;
+let activityNodePulses = new Map();
+let activityEdgePulses = new Map();
+let activityParticles = [];
+let seenEventKeys = new Set();
+let eventPollTimer = null;
+let lastActivityAt = 0;
+let activityEventEdgeKeys = null;
+
+function updateEdgeStrengthScale() {
+  if (!canvasLinks.length) return;
+  const ranked = [...canvasLinks].sort((a, b) => edgeWeight(a) - edgeWeight(b));
+  const denom = Math.max(1, ranked.length - 1);
+  ranked.forEach((edge, index) => {
+    const absolute = Math.sqrt(Math.min(1, edgeWeight(edge)));
+    const rank = index / denom;
+    edge._strength = clamp01((rank * 0.7) + (absolute * 0.3));
+  });
+}
+
+function activityColor(ev) {
+  if (ev.category === 'retrieval') return '#22d3ee';
+  if (ev.category === 'write') return '#86efac';
+  if (ev.category === 'feedback') return ev.data?.useful === false ? '#fb7185' : '#fbbf24';
+  if (ev.category === 'system') return '#a78bfa';
+  return '#38bdf8';
+}
+
+function eventKey(ev) {
+  return [ev.timestamp, ev.category, ev.event, ev.data?.trace_id, ev.data?.grain_id, ev.data?.feature]
+    .filter(Boolean).join('|');
+}
+
+function edgeKey(l) {
+  const sid = typeof l.source === 'object' ? l.source.id : l.source;
+  const tid = typeof l.target === 'object' ? l.target.id : l.target;
+  return `${sid}->${tid}`;
+}
+
+function getPulse(map, key, now) {
+  const pulse = map.get(key);
+  if (!pulse) return null;
+  const remaining = pulse.until - now;
+  if (remaining <= 0) {
+    map.delete(key);
+    return null;
+  }
+  return {...pulse, alpha: clamp01(remaining / pulse.duration)};
+}
+
+function getNodePulse(n, now) { return getPulse(activityNodePulses, n.id, now); }
+function getEdgePulse(l, now) { return getPulse(activityEdgePulses, edgeKey(l), now); }
+
+function setActivityLabel(text, color) {
+  const indicator = document.getElementById('activity-indicator');
+  const label = document.getElementById('activity-text');
+  if (!indicator || !label) return;
+  lastActivityAt = performance.now();
+  indicator.classList.add('live');
+  indicator.style.borderColor = `${color}66`;
+  label.textContent = text;
+}
+
+function pruneActivity(now) {
+  for (const [key, pulse] of activityNodePulses) {
+    if (pulse.until <= now) activityNodePulses.delete(key);
+  }
+  for (const [key, pulse] of activityEdgePulses) {
+    if (pulse.until <= now) activityEdgePulses.delete(key);
+  }
+  activityParticles = activityParticles.filter(p => now - p.start < p.duration);
+  const indicator = document.getElementById('activity-indicator');
+  const label = document.getElementById('activity-text');
+  if (indicator && label && lastActivityAt && now - lastActivityAt > 3500) {
+    indicator.classList.remove('live');
+    indicator.style.borderColor = '';
+    label.textContent = 'watching events';
+  }
+}
+
+function activateEdge(edge, color, now) {
+  const key = edgeKey(edge);
+  if (activityEventEdgeKeys?.has(key)) return;
+  activityEventEdgeKeys?.add(key);
+  activityEdgePulses.set(key, { until: now + 2400, duration: 2400, color });
+  activityParticles.push({ key, edge, start: now, duration: 1800, color });
+  if (activityParticles.length > 700) {
+    activityParticles = activityParticles.slice(-700);
+  }
+}
+
+function activateNode(node, color, now) {
+  if (!node) return 0;
+  activityNodePulses.set(node.id, { until: now + 3200, duration: 3200, color });
+  let count = 1;
+  for (const edge of canvasLinks) {
+    if (edge.source === node || edge.target === node) {
+      activateEdge(edge, color, now);
+      count++;
+    }
+  }
+  return count;
+}
+
+function activateNodeById(id, color, now) {
+  if (!id) return 0;
+  const needle = String(id);
+  const node = canvasNodes.find(n => n.id === needle || n.feature === needle || n.label === needle);
+  return activateNode(node, color, now);
+}
+
+function activateFeature(feature, color, now) {
+  if (!feature) return 0;
+  const needle = String(feature).toLowerCase();
+  let count = 0;
+  for (const node of canvasNodes) {
+    const haystack = [node.feature, node.label, node.id, node.provenance].filter(Boolean).join(' ').toLowerCase();
+    if (haystack.includes(needle)) count += activateNode(node, color, now);
+  }
+  return count;
+}
+
+function handleFluxEvent(ev) {
+  const now = performance.now();
+  const color = activityColor(ev);
+  const data = ev.data || {};
+  let activated = 0;
+  activityEventEdgeKeys = new Set();
+
+  try {
+    activated += activateNodeById(data.grain_id, color, now);
+    if (Array.isArray(data.features)) {
+      for (const feature of data.features.slice(0, 12)) activated += activateFeature(feature, color, now);
+    }
+    activated += activateFeature(data.feature, color, now);
+
+    if (ev.category === 'write' || ev.event === 'grain_stored' || ev.event === 'entry_point_created') {
+      setTimeout(() => fetchAll().catch(err => console.warn('Graph refresh after event failed', err)), 250);
+    }
+
+    const label = ev.category && ev.event ? `${ev.category}/${ev.event}` : 'flux activity';
+    setActivityLabel(label, color);
+    if (activated || ev.category !== 'system') draw();
+  } finally {
+    activityEventEdgeKeys = null;
+  }
+}
+
+async function fetchEvents() {
+  const payload = await fetchJSON('/api/events?limit=50');
+  const events = payload.events || [];
+  const firstLoad = seenEventKeys.size === 0;
+  for (const ev of events.slice().reverse()) {
+    const key = eventKey(ev);
+    if (!key || seenEventKeys.has(key)) continue;
+    seenEventKeys.add(key);
+    const when = Date.parse(ev.timestamp || '');
+    const fresh = Number.isFinite(when) && Date.now() - when < 12000;
+    if (!firstLoad || fresh) handleFluxEvent(ev);
+  }
+  if (seenEventKeys.size > 300) {
+    seenEventKeys = new Set(Array.from(seenEventKeys).slice(-200));
+  }
+}
+
+function startEventPolling() {
+  if (eventPollTimer) return;
+  fetchEvents().catch(err => console.warn('Initial event poll failed', err));
+  eventPollTimer = setInterval(() => {
+    fetchEvents().catch(err => console.warn('Event poll failed', err));
+  }, 1500);
+}
+
+function drawActivityParticles(now) {
+  for (const particle of activityParticles) {
+    const edge = particle.edge;
+    if (!edge?.source || !edge?.target) continue;
+    const sx = edge.source.x, sy = edge.source.y, tx = edge.target.x, ty = edge.target.y;
+    if (sx==null||sy==null||tx==null||ty==null) continue;
+    const raw = clamp01((now - particle.start) / particle.duration);
+    const eased = raw < 0.5 ? 2 * raw * raw : 1 - Math.pow(-2 * raw + 2, 2) / 2;
+    const x = sx + (tx - sx) * eased;
+    const y = sy + (ty - sy) * eased;
+    const tail = Math.max(0, eased - 0.08);
+    const tx2 = sx + (tx - sx) * tail;
+    const ty2 = sy + (ty - sy) * tail;
+    const alpha = Math.sin(raw * Math.PI);
+    ctx.save();
+    ctx.globalAlpha = alpha;
+    ctx.strokeStyle = particle.color;
+    ctx.lineWidth = 2.2 / Math.max(0.65, transform.k);
+    ctx.beginPath();
+    ctx.moveTo(tx2, ty2);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.fillStyle = particle.color;
+    ctx.arc(x, y, 3.5 / Math.max(0.75, transform.k), 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+  }
+}
 
 function updateSearchFocus() {
   searchMatchIds = new Set();
@@ -834,6 +1076,7 @@ function renderGraph() {
     source: nodeMap.get(typeof l.source==='object'?l.source.id:l.source) || (typeof l.source==='object'?l.source.id:l.source),
     target: nodeMap.get(typeof l.target==='object'?l.target.id:l.target) || (typeof l.target==='object'?l.target.id:l.target),
   })).filter(l => l.source && l.target && typeof l.source==='object' && typeof l.target==='object');
+  updateEdgeStrengthScale();
 
   // Set up canvas
   canvas = document.getElementById('graph-canvas');
@@ -908,13 +1151,15 @@ function draw() {
   if (!ctx || !canvas) return;
   const W = canvasCssWidth || canvas.clientWidth;
   const H = canvasCssHeight || canvas.clientHeight;
+  const now = performance.now();
+  pruneActivity(now);
   ctx.setTransform(canvasDpr, 0, 0, canvasDpr, 0, 0);
   ctx.clearRect(0, 0, W, H);
   ctx.save();
   ctx.translate(transform.x, transform.y);
   ctx.scale(transform.k, transform.k);
 
-  const t = performance.now() / 1000;
+  const t = now / 1000;
 
   // Draw edges
   for (const l of canvasLinks) {
@@ -930,13 +1175,26 @@ function draw() {
       (selectedNode && l.source !== selectedNode && l.target !== selectedNode) || isSearchDimmed
     );
 
-    const w = Math.max(0.5, (l.effective_weight??0.3)*2.5);
-    let alpha = isDimmed ? 0.05 : (isSelected||isHovered||isSearchMatch) ? 1 : 0.55;
+    const pulse = getEdgePulse(l, now);
+    const w = edgeWidth(l);
+    let alpha = isDimmed ? 0.035 : (isSelected||isHovered||isSearchMatch||pulse) ? 1 : edgeAlpha(l);
+    const stroke = pulse ? pulse.color : (isSelected || isSearchMatch) ? '#22d3ee' : edgeColor(l);
 
     ctx.save();
+    if (pulse) {
+      ctx.globalAlpha = 0.35 * pulse.alpha;
+      ctx.strokeStyle = pulse.color;
+      ctx.lineWidth = w + 7;
+      ctx.setLineDash([]);
+      ctx.beginPath();
+      ctx.moveTo(sx, sy);
+      ctx.lineTo(tx, ty);
+      ctx.stroke();
+    }
+
     ctx.globalAlpha = alpha;
-    ctx.strokeStyle = (isSelected || isSearchMatch) ? '#22d3ee' : edgeColor(l);
-    ctx.lineWidth = isSelected ? w+1 : isSearchMatch ? w+0.8 : w;
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = isSelected ? w+1.3 : isSearchMatch ? w+1 : w;
 
     // Dashed flow for core/bidirectional
     if (l.decay_class==='core' || l.direction==='bidirectional') {
@@ -956,7 +1214,7 @@ function draw() {
     const r = nodeRadius(l.target)+3;
     const ax = tx - r*Math.cos(angle), ay = ty - r*Math.sin(angle);
     ctx.setLineDash([]);
-    ctx.fillStyle = (isSelected || isSearchMatch) ? '#22d3ee' : edgeColor(l);
+    ctx.fillStyle = stroke;
     ctx.beginPath();
     ctx.moveTo(ax, ay);
     ctx.lineTo(ax - 8*Math.cos(angle-0.4), ay - 8*Math.sin(angle-0.4));
@@ -965,6 +1223,8 @@ function draw() {
     ctx.fill();
     ctx.restore();
   }
+
+  drawActivityParticles(now);
 
   // Draw nodes
   for (const n of canvasNodes) {
@@ -977,7 +1237,8 @@ function draw() {
     const isDimmed = !isSelected && !isHovered && (
       (selectedNode && selectedNode !== n && !isNeighbor(selectedNode, n)) || isSearchDimmed
     );
-    const alpha = isDimmed ? 0.14 : 1;
+    const pulse = getNodePulse(n, now);
+    const alpha = isDimmed && !pulse ? 0.14 : 1;
     const dormant = n.status === 'dormant';
 
     ctx.save();
@@ -1005,6 +1266,26 @@ function draw() {
       ctx.arc(n.x, n.y, glowR+4, 0, Math.PI*2);
       ctx.fillStyle = grad;
       ctx.fill();
+    }
+
+    // Live Flux activity pulse
+    if (pulse) {
+      const pulseR = r + 10 + (1 - pulse.alpha) * 14;
+      const grad = ctx.createRadialGradient(n.x, n.y, r, n.x, n.y, pulseR);
+      grad.addColorStop(0, `${pulse.color}66`);
+      grad.addColorStop(1, `${pulse.color}00`);
+      ctx.globalAlpha = Math.max(0.18, pulse.alpha);
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, pulseR, 0, Math.PI*2);
+      ctx.fillStyle = grad;
+      ctx.fill();
+      ctx.globalAlpha = pulse.alpha;
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, r + 5, 0, Math.PI*2);
+      ctx.strokeStyle = pulse.color;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+      ctx.globalAlpha = alpha;
     }
 
     // Selection ring
@@ -1213,6 +1494,7 @@ function showEdgeTooltip(event, d) {
   showTooltip(event.clientX, event.clientY, `${sid.slice(0,10)}… → ${tid.slice(0,10)}…`, [
     ['weight', (d.weight??0).toFixed(4)],
     ['eff. weight', (d.effective_weight??0).toFixed(4)],
+    ['visual strength', Math.round(edgeStrength(d) * 100) + '%'],
     ['direction', d.direction],
     ['decay', d.decay_class??'—'],
     ['use count', d.use_count??0],
@@ -1356,7 +1638,7 @@ function markInspectorReady() {
 
 // ── INIT ──────────────────────────────────────────────────────────────────────
 window.addEventListener('load', () => {
-  fetchAll();
+  fetchAll().then(() => startEventPolling());
   window.addEventListener('resize', () => { if (graphData) renderGraph(); });
   window.addEventListener('keydown', event => {
     if (event.key === 'Escape' && (selectedNode || selectedEdge)) deselectAll();

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -615,15 +615,42 @@ function edgeColor(l) {
   return '#1e3f5a';
 }
 
+function nodePassesFilters(n) {
+  const typeOk = (n.node_type === 'grain' && activeFilters.grain) || (n.node_type === 'entry' && activeFilters.entry);
+  const statusOk = (n.status === 'active' || !n.status) ? activeFilters.active : (n.status === 'dormant' ? activeFilters.dormant : true);
+  return typeOk && statusOk;
+}
+
+function nodeMatchesSearch(n) {
+  if (!searchQuery) return true;
+  const haystack = [
+    n.label,
+    n.id,
+    n.feature,
+    n.provenance,
+    n.decay_class,
+    n.status,
+  ].filter(Boolean).join(' ').toLowerCase();
+  return haystack.includes(searchQuery);
+}
+
 function getVisibleNodes() {
   if (!graphData) return [];
-  return graphData.nodes.filter(n => {
-    const typeOk = (n.node_type === 'grain' && activeFilters.grain) || (n.node_type === 'entry' && activeFilters.entry);
-    const statusOk = (n.status === 'active' || !n.status) ? activeFilters.active : (n.status === 'dormant' ? activeFilters.dormant : true);
-    const label = String(n.label || '');
-    const searchOk = !searchQuery || label.toLowerCase().includes(searchQuery) || String(n.id || '').includes(searchQuery);
-    return typeOk && statusOk;
-  });
+  const baseNodes = graphData.nodes.filter(nodePassesFilters);
+  if (!searchQuery) return baseNodes;
+
+  const baseIds = new Set(baseNodes.map(n => n.id));
+  const matchedIds = new Set(baseNodes.filter(nodeMatchesSearch).map(n => n.id));
+  const visibleIds = new Set(matchedIds);
+
+  for (const link of graphData.links || []) {
+    const sid = typeof link.source === 'object' ? link.source.id : link.source;
+    const tid = typeof link.target === 'object' ? link.target.id : link.target;
+    if (matchedIds.has(sid) && baseIds.has(tid)) visibleIds.add(tid);
+    if (matchedIds.has(tid) && baseIds.has(sid)) visibleIds.add(sid);
+  }
+
+  return baseNodes.filter(n => visibleIds.has(n.id));
 }
 
 function getVisibleLinks(nodeIds) {

--- a/src/flux/decay.py
+++ b/src/flux/decay.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 
 from .config import Config, DEFAULT_CONFIG
 from .graph import utcnow
+from .health import log_event
 from .propagation import effective_weight
 from .storage import FluxStore
 
@@ -66,11 +67,13 @@ def cleanup_pass(
             store.update_grain_status(grain_id, "dormant", dormant_since=now)
             newly_dormant += 1
 
-    return {
+    stats = {
         "candidates_scanned": len(candidates),
         "conduits_deleted": deleted,
         "grains_marked_dormant": newly_dormant,
     }
+    log_event(store, "decay", "cleanup_pass_completed", stats, now=now)
+    return stats
 
 
 def expiry_pass(
@@ -100,4 +103,6 @@ def expiry_pass(
             store.update_grain_status(grain.id, "archived")
             archived += 1
 
-    return {"grains_archived": archived}
+    stats = {"grains_archived": archived}
+    log_event(store, "decay", "expiry_pass_completed", stats, now=now)
+    return stats

--- a/src/flux/embedding.py
+++ b/src/flux/embedding.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import threading
 from typing import Protocol, runtime_checkable
 
 import numpy as np
@@ -40,15 +41,23 @@ class SentenceTransformerBackend:
     """Wraps sentence-transformers for local embedding (§11.2)."""
 
     def __init__(self, model_name: str = "all-MiniLM-L6-v2") -> None:
-        from sentence_transformers import SentenceTransformer
-        self._model = SentenceTransformer(model_name)
         self._model_name = model_name
+        self._model = None
+        self._lock = threading.Lock()
+
+    def _model_instance(self):
+        if self._model is None:
+            with self._lock:
+                if self._model is None:
+                    from sentence_transformers import SentenceTransformer
+                    self._model = SentenceTransformer(self._model_name)
+        return self._model
 
     def embed(self, text: str) -> list[float]:
-        return self._model.encode(text, convert_to_numpy=True).tolist()
+        return self._model_instance().encode(text, convert_to_numpy=True).tolist()
 
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        return self._model.encode(texts, convert_to_numpy=True).tolist()
+        return self._model_instance().encode(texts, convert_to_numpy=True).tolist()
 
     @property
     def model_name(self) -> str:

--- a/src/flux/embedding.py
+++ b/src/flux/embedding.py
@@ -157,14 +157,14 @@ def vector_fallback(
 
     Returns merged list of (grain_id, score) sorted descending.
     """
+    grain_ids, matrix = load_all_embeddings(store)
+    if not grain_ids:
+        return existing_results
+
     try:
         query_embedding = backend.embed(query_text)
     except Exception as exc:
         logger.error("vector_fallback: embedding failed: %s", exc)
-        return existing_results
-
-    grain_ids, matrix = load_all_embeddings(store)
-    if not grain_ids:
         return existing_results
 
     candidates = top_k_nearest(query_embedding, grain_ids, matrix, k=cfg.VECTOR_FALLBACK_K)

--- a/src/flux/extraction.py
+++ b/src/flux/extraction.py
@@ -130,10 +130,6 @@ def extract_and_store_grains(
     if not grain_dicts:
         return []
 
-    # Load existing embeddings once for the bootstrap neighbour search.
-    existing_grain_ids, existing_matrix = load_all_embeddings(store)
-    model_name = getattr(embedding_backend, "model_name", "unknown")
-
     new_grain_ids: list[str] = []
     for gd in grain_dicts:
         content = gd.get("content", "").strip()
@@ -141,55 +137,169 @@ def extract_and_store_grains(
         if not content:
             continue
 
-        grain = Grain(content=content, provenance=provenance, created_at=now)
-        store.insert_grain(grain)
-        new_grain_ids.append(grain.id)
-        log_event(store, "write", "grain_stored", {
-            "grain_id": grain.id,
-            "provenance": provenance,
-            "content_len": len(content),
-        }, now=now)
-
-        # Bootstrap: embed once, find neighbours, create conduits.
-        try:
-            embedding = embedding_backend.embed(content)
-        except Exception as exc:
-            logger.error("extract_and_store_grains: embedding failed for grain %s: %s", grain.id, exc)
-            continue
-
-        if existing_grain_ids:
-            neighbours = top_k_nearest(embedding, existing_grain_ids, existing_matrix, k=5)
-            for neighbour_id, similarity in neighbours:
-                if similarity <= 0:
-                    continue
-                weight = similarity * cfg.INITIAL_WEIGHT_SCALE
-                if weight < cfg.WEIGHT_FLOOR:
-                    continue
-                conduit = Conduit(
-                    from_id=grain.id,
-                    to_id=neighbour_id,
-                    weight=weight,
-                    created_at=now,
-                    last_used=now,
-                    direction="bidirectional",
-                    decay_class="working",
-                )
-                try:
-                    store.insert_conduit(conduit)
-                except Exception:
-                    pass  # UNIQUE constraint: conduit already exists; skip silently.
-
-        # Store the embedding for future fallback use.
-        store_embedding(store, grain.id, embedding, model_name, now)
-
-        # Connect to entry points extracted from the grain's content.
-        _connect_to_entries(grain, llm, store, cfg, now)
+        grain_id = store_atomic_grain(
+            content,
+            provenance,
+            llm=llm,
+            embedding_backend=embedding_backend,
+            store=store,
+            cfg=cfg,
+            now=now,
+        )
+        new_grain_ids.append(grain_id)
 
     log_event(store, "write", "bootstrap_conduits_created", {
         "grains_stored": len(new_grain_ids),
     }, now=now)
 
     return new_grain_ids
+
+
+def store_atomic_grain(
+    content: str,
+    provenance: str,
+    *,
+    llm: LLMBackend,
+    embedding_backend: EmbeddingBackend,
+    store: FluxStore,
+    cfg: Config = DEFAULT_CONFIG,
+    now: datetime | None = None,
+) -> str:
+    """Store one already-atomic grain and wire it into the graph.
+
+    This is the caller_extracts path: the caller has already decided the memory
+    is worth storing, so Flux should still create embeddings and entry conduits
+    even when the local LLM cannot perform full grain extraction.
+    """
+    now = now or utcnow()
+    grain = Grain(content=content, provenance=provenance, created_at=now)
+    store.insert_grain(grain)
+    log_event(store, "write", "grain_stored", {
+        "grain_id": grain.id,
+        "provenance": provenance,
+        "content_len": len(content),
+    }, now=now)
+    backfill_grain_graph(grain, llm=llm, embedding_backend=embedding_backend,
+                         store=store, cfg=cfg, now=now)
+    return grain.id
+
+
+def backfill_grain_graph(
+    grain: Grain,
+    *,
+    llm: LLMBackend,
+    embedding_backend: EmbeddingBackend,
+    store: FluxStore,
+    cfg: Config = DEFAULT_CONFIG,
+    now: datetime | None = None,
+) -> dict:
+    """Create missing embedding, neighbour conduits, and entry conduits for a grain."""
+    now = now or utcnow()
+    before_edges = _count_conduits(store)
+    embedding_created = False
+
+    row = store.conn.execute(
+        "SELECT 1 FROM grain_embeddings WHERE grain_id = ?",
+        (grain.id,),
+    ).fetchone()
+
+    if row is None:
+        existing_grain_ids, existing_matrix = load_all_embeddings(store)
+        model_name = getattr(embedding_backend, "model_name", "unknown")
+        try:
+            embedding = embedding_backend.embed(grain.content)
+            embedding_created = True
+        except Exception as exc:
+            logger.error("backfill_grain_graph: embedding failed for grain %s: %s", grain.id, exc)
+        else:
+            if existing_grain_ids:
+                neighbours = top_k_nearest(embedding, existing_grain_ids, existing_matrix, k=5)
+                for neighbour_id, similarity in neighbours:
+                    if similarity <= 0:
+                        continue
+                    weight = similarity * cfg.INITIAL_WEIGHT_SCALE
+                    if weight < cfg.WEIGHT_FLOOR:
+                        continue
+                    conduit = Conduit(
+                        from_id=grain.id,
+                        to_id=neighbour_id,
+                        weight=weight,
+                        created_at=now,
+                        last_used=now,
+                        direction="bidirectional",
+                        decay_class="working",
+                    )
+                    try:
+                        store.insert_conduit(conduit)
+                    except Exception:
+                        pass
+            store_embedding(store, grain.id, embedding, model_name, now)
+
+    _connect_to_entries(grain, llm, store, cfg, now)
+    after_edges = _count_conduits(store)
+    return {
+        "grain_id": grain.id,
+        "embedding_created": embedding_created,
+        "conduits_created": after_edges - before_edges,
+    }
+
+
+def rebuild_missing_graph(
+    store: FluxStore,
+    llm: LLMBackend,
+    embedding_backend: EmbeddingBackend,
+    cfg: Config = DEFAULT_CONFIG,
+    *,
+    limit: int | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Backfill graph artifacts for active grains missing embeddings or inbound routes."""
+    now = now or utcnow()
+    scanned = 0
+    rebuilt = 0
+    embeddings_created = 0
+    conduits_created = 0
+
+    for grain in store.iter_grains(status="active"):
+        if limit is not None and rebuilt >= limit:
+            break
+        scanned += 1
+        has_embedding = store.conn.execute(
+            "SELECT 1 FROM grain_embeddings WHERE grain_id = ?",
+            (grain.id,),
+        ).fetchone() is not None
+        has_inbound = store.count_inbound_conduits(grain.id) > 0
+        if has_embedding and has_inbound:
+            continue
+        stats = backfill_grain_graph(
+            grain,
+            llm=llm,
+            embedding_backend=embedding_backend,
+            store=store,
+            cfg=cfg,
+            now=now,
+        )
+        rebuilt += 1
+        embeddings_created += 1 if stats["embedding_created"] else 0
+        conduits_created += stats["conduits_created"]
+
+    log_event(store, "write", "graph_rebuild_completed", {
+        "grains_scanned": scanned,
+        "grains_rebuilt": rebuilt,
+        "embeddings_created": embeddings_created,
+        "conduits_created": conduits_created,
+    }, now=now)
+    return {
+        "grains_scanned": scanned,
+        "grains_rebuilt": rebuilt,
+        "embeddings_created": embeddings_created,
+        "conduits_created": conduits_created,
+    }
+
+
+def _count_conduits(store: FluxStore) -> int:
+    row = store.conn.execute("SELECT COUNT(*) AS n FROM conduits").fetchone()
+    return int(row["n"] if row else 0)
 
 
 def _connect_to_entries(

--- a/src/flux/health.py
+++ b/src/flux/health.py
@@ -311,6 +311,22 @@ def _compute_event_signals(store: FluxStore, now: datetime) -> dict[str, float]:
         ).fetchone()
         return int(r["n"]) if r else 0
 
+    def _count_trace_scoped(category: str, event: str, cutoff: str) -> int:
+        """Count one event per trace when trace_id exists, plus legacy untraced events."""
+        r = store.conn.execute(
+            """
+            SELECT
+              COUNT(DISTINCT NULLIF(trace_id, '')) AS traced,
+              SUM(CASE WHEN trace_id IS NULL OR trace_id = '' THEN 1 ELSE 0 END) AS untraced
+            FROM events
+            WHERE category=? AND event=? AND timestamp>=?
+            """,
+            (category, event, cutoff),
+        ).fetchone()
+        if not r:
+            return 0
+        return int(r["traced"] or 0) + int(r["untraced"] or 0)
+
     # Highway growth rate: new conduits that crossed weight 0.80 (proxied by
     # reinforce events that set weight above 0.80, logged in feedback events).
     hgr = store.conn.execute(
@@ -361,9 +377,9 @@ def _compute_event_signals(store: FluxStore, now: datetime) -> dict[str, float]:
     signals["avg_hops_per_retrieval"] = float(hops["a"] or 0.0) if hops else 0.0
 
     # Retrieval success rate: % where at least one grain was marked useful.
-    ret_total = _count("retrieval", "grains_returned", cutoff_short) or 0
-    ret_success = _count("feedback", "retrieval_successful", cutoff_short)
-    signals["retrieval_success_rate"] = ret_success / ret_total if ret_total > 0 else 0.0
+    ret_total = _count_trace_scoped("retrieval", "grains_returned", cutoff_short)
+    ret_success = _count_trace_scoped("feedback", "retrieval_successful", cutoff_short)
+    signals["retrieval_success_rate"] = min(ret_success / ret_total, 1.0) if ret_total > 0 else 0.0
 
     # Fallback trigger rate.
     fallbacks = _count("retrieval", "fallback_triggered", cutoff_short)

--- a/src/flux/promotion.py
+++ b/src/flux/promotion.py
@@ -31,6 +31,7 @@ from typing import Iterable
 
 from .config import Config, DEFAULT_CONFIG
 from .graph import utcnow
+from .health import log_event
 from .propagation import TraceStep
 from .storage import FluxStore
 
@@ -41,6 +42,7 @@ def check_promotion(
     trace: list[TraceStep],
     cfg: Config = DEFAULT_CONFIG,
     now: datetime | None = None,
+    trace_id: str | None = None,
 ) -> bool:
     """Run the promotion check for one grain after a successful retrieval.
 
@@ -71,8 +73,18 @@ def check_promotion(
 
     # 5. Promote if threshold reached.
     if spread >= cfg.PROMOTION_THRESHOLD:
+        inbound_before = store.conn.execute(
+            "SELECT COUNT(*) AS n FROM conduits WHERE to_id = ? AND decay_class != 'core'",
+            (grain_id,),
+        ).fetchone()
         store.promote_grain_to_core(grain_id)
         store.upgrade_inbound_conduits_to_core(grain_id)
+        log_event(store, "feedback", "promotion_triggered", {
+            "grain_id": grain_id,
+            "context_spread": spread,
+            "promotion_threshold": cfg.PROMOTION_THRESHOLD,
+            "inbound_conduits_upgraded": int(inbound_before["n"] if inbound_before else 0),
+        }, trace_id=trace_id, now=now)
         return True
 
     return False
@@ -84,6 +96,7 @@ def check_promotions_bulk(
     trace: list[TraceStep],
     cfg: Config = DEFAULT_CONFIG,
     now: datetime | None = None,
+    trace_id: str | None = None,
 ) -> list[str]:
     """Run promotion checks for a batch of grains from the same retrieval.
 
@@ -92,7 +105,7 @@ def check_promotions_bulk(
     now = now or utcnow()
     promoted = []
     for grain_id in grain_ids:
-        if check_promotion(store, grain_id, trace, cfg, now=now):
+        if check_promotion(store, grain_id, trace, cfg, now=now, trace_id=trace_id):
             promoted.append(grain_id)
     return promoted
 

--- a/src/flux/reinforcement.py
+++ b/src/flux/reinforcement.py
@@ -27,8 +27,11 @@ from typing import Iterable
 
 from .config import Config, DEFAULT_CONFIG
 from .graph import Conduit, utcnow
+from .health import log_event
 from .propagation import TraceStep, effective_weight
 from .storage import FluxStore
+
+HIGHWAY_WEIGHT_THRESHOLD = 0.80
 
 
 # --------------------------------------------------------------------- reinforce
@@ -39,6 +42,7 @@ def reinforce(
     cfg: Config = DEFAULT_CONFIG,
     *,
     now: datetime | None = None,
+    trace_id: str | None = None,
 ) -> None:
     """Widen conduits on the successful trace, upsert co-retrieval counts,
     create/reinforce shortcuts between successful pairs, sharpen affinities."""
@@ -56,7 +60,7 @@ def reinforce(
             continue
         target = store.get_grain(step.to_id)
         multiplier = cfg.provenance_multiplier(target.provenance) if target else 1.0
-        _widen(store, conduit, cfg, now, multiplier=multiplier)
+        _widen(store, conduit, cfg, now, multiplier=multiplier, trace_id=trace_id)
 
     # 2. Co-retrieval counts and shortcut creation between every successful pair.
     successful_list = sorted(successful)  # stable iteration
@@ -66,9 +70,9 @@ def reinforce(
             count = store.increment_co_retrieval(a, b, delta=1)
             existing = store.conduit_between(a, b)
             if existing is not None:
-                _widen(store, existing, cfg, now)
+                _widen(store, existing, cfg, now, trace_id=trace_id)
             elif count >= cfg.SHORTCUT_THRESHOLD:
-                _create_shortcut(store, a, b, cfg, now)
+                _create_shortcut(store, a, b, cfg, now, co_count=count, trace_id=trace_id)
 
     # 3. Sharpen entry affinities on successful first hops. Entries are
     #    identified by the trace step's from_id when hop == 0.
@@ -91,6 +95,7 @@ def penalize(
     cfg: Config = DEFAULT_CONFIG,
     *,
     now: datetime | None = None,
+    trace_id: str | None = None,
 ) -> None:
     """Narrow conduits to failed grains; delete if weight falls below floor.
     Dampen entry affinities on failed first hops."""
@@ -109,10 +114,23 @@ def penalize(
         # starvation, not from explicit negative feedback.
         current = effective_weight(conduit, cfg, now, apply_grace_floor=False)
         new_weight = current * cfg.DECAY_FACTOR
+        weight_drop = max(current - new_weight, 0.0)
         if new_weight < cfg.WEIGHT_FLOOR:
             store.delete_conduit(conduit.id)
+            deleted = True
         else:
             store.update_conduit_weight(conduit.id, new_weight, now)
+            deleted = False
+
+        log_event(store, "feedback", "conduit_penalized", {
+            "conduit_id": conduit.id,
+            "from_id": conduit.from_id,
+            "to_id": conduit.to_id,
+            "previous_weight": round(current, 6),
+            "new_weight": round(new_weight, 6),
+            "weight_drop": round(weight_drop, 6),
+            "deleted": deleted,
+        }, trace_id=trace_id, now=now)
 
         if step.hop == 0:
             entry = store.get_entry(step.from_id)
@@ -130,6 +148,7 @@ def _widen(
     now: datetime,
     *,
     multiplier: float = 1.0,
+    trace_id: str | None = None,
 ) -> None:
     """weight += LEARNING_RATE * multiplier * (1 - weight), clamped by ceiling.
     Applies lazy decay first so the delta is relative to the current
@@ -140,6 +159,26 @@ def _widen(
     store.update_conduit_weight(
         conduit.id, new_weight, now, use_count=conduit.use_count + 1
     )
+    log_event(store, "feedback", "conduit_reinforced", {
+        "conduit_id": conduit.id,
+        "from_id": conduit.from_id,
+        "to_id": conduit.to_id,
+        "previous_weight": round(current, 6),
+        "new_weight": round(new_weight, 6),
+        "delta": round(new_weight - current, 6),
+        "multiplier": round(multiplier, 6),
+        "use_count": conduit.use_count + 1,
+    }, trace_id=trace_id, now=now)
+
+    if current < HIGHWAY_WEIGHT_THRESHOLD <= new_weight:
+        log_event(store, "feedback", "highway_formed", {
+            "conduit_id": conduit.id,
+            "from_id": conduit.from_id,
+            "to_id": conduit.to_id,
+            "previous_weight": round(current, 6),
+            "new_weight": round(new_weight, 6),
+            "threshold": HIGHWAY_WEIGHT_THRESHOLD,
+        }, trace_id=trace_id, now=now)
 
 
 def _create_shortcut(
@@ -148,6 +187,9 @@ def _create_shortcut(
     grain_b: str,
     cfg: Config,
     now: datetime,
+    *,
+    co_count: int,
+    trace_id: str | None = None,
 ) -> None:
     """Create a bidirectional shortcut. Enforce MAX_EDGES_PER_GRAIN by evicting
     the weakest edge on any saturated endpoint first (Section 4.3)."""
@@ -174,6 +216,14 @@ def _create_shortcut(
         direction="bidirectional",
     )
     store.insert_conduit(shortcut)
+    log_event(store, "feedback", "shortcut_created", {
+        "conduit_id": shortcut.id,
+        "from_id": shortcut.from_id,
+        "to_id": shortcut.to_id,
+        "weight": round(shortcut.weight, 6),
+        "co_retrieval_count": co_count,
+        "threshold": cfg.SHORTCUT_THRESHOLD,
+    }, trace_id=trace_id, now=now)
 
 
 def _evict_weakest(

--- a/src/flux/rest_api.py
+++ b/src/flux/rest_api.py
@@ -1,7 +1,8 @@
 """REST API for Flux Memory (§1A.4).
 
 Exposes all public operations over HTTP using FastAPI.
-Runs alongside the MCP server and Python SDK — same operations, three equal paths.
+Runs alongside the dashboard and Python SDK. MCP clients launch the stdio
+MCP server separately with `flux mcp --name <instance>`.
 
 Endpoints:
   POST /store              store a grain (or batch)
@@ -80,6 +81,22 @@ def build_app(service: "FluxService", cfg: "Config" = DEFAULT_CONFIG):
     # ------------------------------------------------------------------
     # Endpoints
     # ------------------------------------------------------------------
+
+    @app.get("/")
+    def root():
+        return {
+            "name": "Flux Memory",
+            "version": "0.6.0",
+            "health": "/health",
+            "docs": "/docs",
+            "endpoints": {
+                "store": "/store",
+                "store_batch": "/store/batch",
+                "retrieve": "/retrieve",
+                "feedback": "/feedback",
+                "grains": "/grains",
+            },
+        }
 
     @app.post("/store")
     def store(body: StoreRequest, request: Request):

--- a/src/flux/rest_api.py
+++ b/src/flux/rest_api.py
@@ -68,7 +68,7 @@ def build_app(service: "FluxService", cfg: "Config" = DEFAULT_CONFIG):
     app = FastAPI(
         title="Flux Memory",
         description="Self-organizing retrieval fabric for AI memory.",
-        version="0.6.0",
+        version="0.6.1",
     )
 
     # ------------------------------------------------------------------
@@ -86,7 +86,7 @@ def build_app(service: "FluxService", cfg: "Config" = DEFAULT_CONFIG):
     def root():
         return {
             "name": "Flux Memory",
-            "version": "0.6.0",
+            "version": "0.6.1",
             "health": "/health",
             "docs": "/docs",
             "endpoints": {

--- a/src/flux/retrieval.py
+++ b/src/flux/retrieval.py
@@ -25,7 +25,7 @@ from typing import Any
 from .config import Config, DEFAULT_CONFIG
 from .embedding import EmbeddingBackend, vector_fallback
 from .expansion import expand_results
-from .extraction import decompose_query, extract_and_store_grains
+from .extraction import decompose_query, extract_and_store_grains, store_atomic_grain
 from .graph import Grain, Trace, new_id, utcnow
 from .health import log_event
 from .llm import LLMBackend
@@ -101,7 +101,17 @@ def flux_store(
         )
         if grain_ids:
             return grain_ids[0]
-        # Fallback: LLM produced no grains; store manually.
+        # Fallback: the caller already supplied an atomic fact, so store it and
+        # still wire it into the graph with embeddings and entry conduits.
+        return store_atomic_grain(
+            content,
+            provenance,
+            llm=llm,
+            embedding_backend=emb,
+            store=store,
+            cfg=cfg,
+            now=now,
+        )
 
     grain = Grain(content=content, provenance=provenance, created_at=now)
     store.insert_grain(grain)

--- a/src/flux/retrieval.py
+++ b/src/flux/retrieval.py
@@ -29,6 +29,7 @@ from .extraction import decompose_query, extract_and_store_grains, store_atomic_
 from .graph import Grain, Trace, new_id, utcnow
 from .health import log_event
 from .llm import LLMBackend
+from .promotion import check_promotion
 from .propagation import PropagationResult, TraceStep, propagate, retrieval_confidence
 from .reinforcement import penalize, reinforce
 from .storage import FluxStore
@@ -280,10 +281,11 @@ def flux_feedback(
     effective_signal = base_signal * trend_modulator * provenance_modulator
 
     if effective_signal > 0:
-        reinforce(store, trace_steps, [grain_id], cfg=cfg, now=now)
+        reinforce(store, trace_steps, [grain_id], cfg=cfg, now=now, trace_id=trace_id)
+        check_promotion(store, grain_id, trace_steps, cfg=cfg, now=now, trace_id=trace_id)
         action = "reinforced"
     else:
-        penalize(store, trace_steps, [grain_id], cfg=cfg, now=now)
+        penalize(store, trace_steps, [grain_id], cfg=cfg, now=now, trace_id=trace_id)
         action = "penalized"
 
     # Record usefulness event so future ratio queries can use it.

--- a/src/flux/service.py
+++ b/src/flux/service.py
@@ -157,11 +157,28 @@ class FluxService:
 
     def retrieve(self, query: str, caller_id: str = "default") -> RetrievalResult:
         """Submit a retrieve to the read booth (blocking, returns result)."""
-        future = self._executor.submit(
-            flux_retrieve, query,
-            store=self._store, llm=self._llm, emb=self._emb, cfg=self._cfg,
-        )
+        future = self._executor.submit(self._retrieve_worker, query)
         return future.result()
+
+    def _retrieve_worker(self, query: str) -> RetrievalResult:
+        """Run one retrieve using a worker-local SQLite connection."""
+        if self._store.db_path == ":memory:":
+            return flux_retrieve(
+                query,
+                store=self._store,
+                llm=self._llm,
+                emb=self._emb,
+                cfg=self._cfg,
+            )
+
+        with FluxStore(self._store.db_path) as read_store:
+            return flux_retrieve(
+                query,
+                store=read_store,
+                llm=self._llm,
+                emb=self._emb,
+                cfg=self._cfg,
+            )
 
     def store(self, content: str, provenance: str = "ai_stated",
               caller_id: str = "default") -> str:

--- a/src/flux/storage.py
+++ b/src/flux/storage.py
@@ -38,6 +38,7 @@ class FluxStore:
         self.conn.execute("PRAGMA journal_mode=WAL")
         self.conn.execute("PRAGMA foreign_keys=ON")
         self.conn.execute("PRAGMA synchronous=NORMAL")
+        self.conn.execute("PRAGMA busy_timeout=30000")
         self._ensure_schema()
 
     def close(self) -> None:

--- a/src/flux/visualization.py
+++ b/src/flux/visualization.py
@@ -59,6 +59,7 @@ def export_json(store: FluxStore, now: datetime | None = None) -> dict:
     return {
         "directed": True,
         "multigraph": False,
+        "stats": _graph_stats(store),
         "nodes": [{"id": n["id"], **{k: v for k, v in n.items() if k != "id"}}
                   for n in nodes],
         "links": [{"source": e["source"], "target": e["target"],
@@ -183,6 +184,27 @@ def _load_graph(store: FluxStore, now: datetime) -> tuple[list[dict], list[dict]
         })
 
     return nodes, edges
+
+
+def _graph_stats(store: FluxStore) -> dict[str, int]:
+    def count(sql: str) -> int:
+        row = store.conn.execute(sql).fetchone()
+        return int(row["n"] if row else 0)
+
+    grains = count("SELECT COUNT(*) AS n FROM grains")
+    active_grains = count("SELECT COUNT(*) AS n FROM grains WHERE status='active'")
+    entries = count("SELECT COUNT(*) AS n FROM entries")
+    conduits = count("SELECT COUNT(*) AS n FROM conduits")
+    embeddings = count("SELECT COUNT(*) AS n FROM grain_embeddings")
+    dormant_grains = count("SELECT COUNT(*) AS n FROM grains WHERE status='dormant'")
+    return {
+        "grains": grains,
+        "active_grains": active_grains,
+        "dormant_grains": dormant_grains,
+        "entries": entries,
+        "conduits": conduits,
+        "embeddings": embeddings,
+    }
 
 
 def _add_graphml_keys(root: ET.Element) -> None:

--- a/src/flux/visualization.py
+++ b/src/flux/visualization.py
@@ -173,6 +173,7 @@ def _load_graph(store: FluxStore, now: datetime) -> tuple[list[dict], list[dict]
         direction = c.direction or "forward"
         edge_type = "shortcut" if direction == "bidirectional" and c.use_count > 0 else "earned"
         edges.append({
+            "id": c.id,
             "source": c.from_id,
             "target": c.to_id,
             "weight": c.weight,

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -175,6 +175,22 @@ class TestAdminAuthTOTP:
         token = auth.authenticate("goodpassword", totp_code=code)
         assert token
 
+    def test_verify_totp_code(self, auth):
+        try:
+            import pyotp
+        except ImportError:
+            pytest.skip("pyotp not installed")
+        uri = auth.setup("goodpassword", enable_totp=True)
+        secret = uri.split("secret=")[1].split("&")[0]
+        assert auth.verify_totp_code(pyotp.TOTP(secret).now())
+        assert not auth.verify_totp_code("000000")
+
+    def test_disable_totp(self, auth):
+        auth.setup("goodpassword", enable_totp=True)
+        auth.disable_totp()
+        assert auth.totp_uri() is None
+        assert auth.authenticate("goodpassword")
+
     def test_totp_uri_not_none_when_enabled(self, auth):
         try:
             import pyotp  # noqa: F401

--- a/tests/test_cli_v6.py
+++ b/tests/test_cli_v6.py
@@ -50,6 +50,32 @@ class TestStartHelp:
         assert "Launch REST API and dashboard" in result.output
 
 
+class TestWarmupCommand:
+    def test_warmup_command_loads_configured_embedding_model(self, tmp_path, monkeypatch):
+        _make_instance(tmp_path, monkeypatch)
+        calls = []
+
+        def fake_warmup(cfg):
+            calls.append(cfg.EMBEDDING_MODEL_NAME)
+            return cfg.EMBEDDING_MODEL_NAME, 384, 0.01
+
+        monkeypatch.setattr(flux_cli, "_warmup_embedding_model", fake_warmup)
+
+        result = CliRunner().invoke(flux_cli.cli, ["warmup", "--name", "test1"])
+
+        assert result.exit_code == 0
+        assert calls == ["all-MiniLM-L6-v2"]
+        assert "Embedding model warmed: all-MiniLM-L6-v2 (384 dims, 0.01s)" in result.output
+
+    def test_warmup_command_requires_initialized_instance(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(flux_cli, "_FLUX_HOME", tmp_path)
+
+        result = CliRunner().invoke(flux_cli.cli, ["warmup", "--name", "missing"])
+
+        assert result.exit_code == 1
+        assert "Instance 'missing' not initialized" in result.output
+
+
 class TestMCPMessaging:
     def test_mcp_client_config_hint_points_to_codex_snippet(self, monkeypatch):
         monkeypatch.setattr(flux_cli, "_FLUX_HOME", Path("flux-home"))

--- a/tests/test_cli_v6.py
+++ b/tests/test_cli_v6.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -47,3 +48,14 @@ class TestStartHelp:
 
         assert result.exit_code == 0
         assert "Launch REST API and dashboard" in result.output
+
+
+class TestMCPMessaging:
+    def test_mcp_client_config_hint_points_to_codex_snippet(self, monkeypatch):
+        monkeypatch.setattr(flux_cli, "_FLUX_HOME", Path("flux-home"))
+
+        assert str(flux_cli._mcp_client_config_hint("test1")).endswith(
+            "test1\\integrations\\codex.toml"
+        ) or str(flux_cli._mcp_client_config_hint("test1")).endswith(
+            "test1/integrations/codex.toml"
+        )

--- a/tests/test_cli_v6.py
+++ b/tests/test_cli_v6.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -74,6 +75,52 @@ class TestWarmupCommand:
 
         assert result.exit_code == 1
         assert "Instance 'missing' not initialized" in result.output
+
+
+class TestRebuildGraphCommand:
+    def test_rebuild_graph_command_reports_stats(self, tmp_path, monkeypatch):
+        _make_instance(tmp_path, monkeypatch)
+
+        def fake_rebuild(name, limit=None):
+            assert name == "test1"
+            assert limit == 12
+            return {
+                "grains_scanned": 15,
+                "grains_rebuilt": 10,
+                "embeddings_created": 9,
+                "conduits_created": 42,
+            }
+
+        monkeypatch.setattr(flux_cli, "_rebuild_instance_graph", fake_rebuild)
+
+        result = CliRunner().invoke(
+            flux_cli.cli,
+            ["rebuild-graph", "--name", "test1", "--limit", "12"],
+        )
+
+        assert result.exit_code == 0
+        assert "Graph rebuild complete: 10 rebuilt, 9 embeddings, 42 conduits" in result.output
+
+    def test_rebuild_graph_requires_initialized_instance(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(flux_cli, "_FLUX_HOME", tmp_path)
+
+        result = CliRunner().invoke(flux_cli.cli, ["rebuild-graph", "--name", "missing"])
+
+        assert result.exit_code == 1
+        assert "Instance 'missing' not initialized" in result.output
+
+    def test_rebuild_graph_reports_locked_database(self, tmp_path, monkeypatch):
+        _make_instance(tmp_path, monkeypatch)
+
+        def fake_rebuild(name, limit=None):
+            raise sqlite3.OperationalError("database is locked")
+
+        monkeypatch.setattr(flux_cli, "_rebuild_instance_graph", fake_rebuild)
+
+        result = CliRunner().invoke(flux_cli.cli, ["rebuild-graph", "--name", "test1"])
+
+        assert result.exit_code == 1
+        assert "Database is locked" in result.output
 
 
 class TestMCPMessaging:

--- a/tests/test_cli_v6.py
+++ b/tests/test_cli_v6.py
@@ -49,6 +49,12 @@ class TestStartHelp:
 
         assert result.exit_code == 0
         assert "Launch REST API and dashboard" in result.output
+        assert "--broadcast" in result.output
+
+    def test_dashboard_probe_host_uses_loopback_for_broadcast_bind(self):
+        assert flux_cli._dashboard_probe_host("0.0.0.0") == "127.0.0.1"
+        assert flux_cli._dashboard_probe_host("::") == "127.0.0.1"
+        assert flux_cli._dashboard_probe_host("localhost") == "localhost"
 
 
 class TestWarmupCommand:

--- a/tests/test_cli_v6.py
+++ b/tests/test_cli_v6.py
@@ -1,0 +1,49 @@
+"""Tests for CLI integration helpers."""
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+import flux.cli as flux_cli
+
+
+def _make_instance(tmp_path, monkeypatch, name="test1"):
+    monkeypatch.setattr(flux_cli, "_FLUX_HOME", tmp_path)
+    idir = tmp_path / name
+    idir.mkdir(parents=True)
+    (idir / "config.yaml").write_text(
+        "MCP_SERVER_NAME: test1\nOPERATING_MODE: caller_extracts\n",
+        encoding="utf-8",
+    )
+    return idir
+
+
+class TestMCPClientConfig:
+    def test_write_mcp_client_configs(self, tmp_path, monkeypatch):
+        _make_instance(tmp_path, monkeypatch)
+        paths = flux_cli._write_mcp_client_configs("test1")
+
+        assert paths["codex"].exists()
+        codex = paths["codex"].read_text(encoding="utf-8")
+        assert '[mcp_servers."flux-test1"]' in codex
+        assert '"-m", "flux.cli", "mcp", "--name", "test1"' in codex
+
+        claude = json.loads(paths["claude"].read_text(encoding="utf-8"))
+        assert claude["mcpServers"]["flux-test1"]["args"][-2:] == ["--name", "test1"]
+
+    def test_mcp_config_command_writes_snippets(self, tmp_path, monkeypatch):
+        _make_instance(tmp_path, monkeypatch)
+        result = CliRunner().invoke(flux_cli.cli, ["mcp-config", "--name", "test1"])
+
+        assert result.exit_code == 0
+        assert "MCP client snippets written" in result.output
+        assert (tmp_path / "test1" / "integrations" / "codex.toml").exists()
+
+
+class TestStartHelp:
+    def test_start_help_does_not_claim_to_start_mcp_stdio(self):
+        result = CliRunner().invoke(flux_cli.cli, ["start", "--help"])
+
+        assert result.exit_code == 0
+        assert "Launch REST API and dashboard" in result.output

--- a/tests/test_dashboard_activity.py
+++ b/tests/test_dashboard_activity.py
@@ -1,6 +1,8 @@
 """Dashboard activity animation coverage."""
 from __future__ import annotations
 
+import re
+
 from flux import dashboard
 
 
@@ -24,9 +26,19 @@ def test_dashboard_animates_conduit_specific_events() -> None:
         assert event_name in html
 
 
-def test_dashboard_refreshes_after_conduit_graph_changes() -> None:
+def test_dashboard_refreshes_after_structural_graph_changes_only() -> None:
     html = dashboard._DASHBOARD_HTML
 
     assert "function isGraphRefreshEvent(ev)" in html
-    assert "function scheduleGraphRefreshAfterEvent(ev, color)" in html
-    assert "isConduitEvent(ev)" in html
+    refresh_match = re.search(r"function isGraphRefreshEvent\(ev\) \{(?P<body>.*?)\n\}", html, re.S)
+    assert refresh_match is not None
+    refresh_body = refresh_match.group("body")
+
+    assert "ev.category === 'write'" not in refresh_body
+    assert "isConduitEvent(ev)" not in refresh_body
+    assert "ev.event === 'grain_stored'" in refresh_body
+    assert "ev.event === 'entry_point_created'" in refresh_body
+    assert "ev.event === 'bootstrap_conduits_created'" in refresh_body
+    assert "ev.event === 'graph_rebuild_completed'" in refresh_body
+    assert "function scheduleGraphRefreshAfterEvent()" in html
+    assert "}, 1200);" in html

--- a/tests/test_dashboard_activity.py
+++ b/tests/test_dashboard_activity.py
@@ -1,0 +1,32 @@
+"""Dashboard activity animation coverage."""
+from __future__ import annotations
+
+from flux import dashboard
+
+
+def test_dashboard_animates_conduit_specific_events() -> None:
+    html = dashboard._DASHBOARD_HTML
+
+    assert "function isConduitEvent(ev)" in html
+    assert "function activateConduitEvent(ev, color, now)" in html
+    assert "function findConduitEdge(data)" in html
+    assert "data.conduit_id" in html
+    assert "pulseNodeById(data.from_id" in html
+    assert "pulseNodeById(data.to_id" in html
+    assert "activateEdge(edge, color, now)" in html
+
+    for event_name in (
+        "conduit_reinforced",
+        "conduit_penalized",
+        "highway_formed",
+        "shortcut_created",
+    ):
+        assert event_name in html
+
+
+def test_dashboard_refreshes_after_conduit_graph_changes() -> None:
+    html = dashboard._DASHBOARD_HTML
+
+    assert "function isGraphRefreshEvent(ev)" in html
+    assert "function scheduleGraphRefreshAfterEvent(ev, color)" in html
+    assert "isConduitEvent(ev)" in html

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -1,6 +1,7 @@
 """Tests for decay.py — cleanup_pass and expiry_pass (Track 1 Steps 5-6)."""
 from __future__ import annotations
 
+import json
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -198,6 +199,20 @@ class TestCleanupPass:
         assert "conduits_deleted" in stats
         assert "grains_marked_dormant" in stats
 
+    def test_cleanup_pass_logs_health_facing_event(self, store):
+        cfg = Config(CLEANUP_STALE_HOURS=1, CLEANUP_BATCH_SIZE=100)
+
+        stats = cleanup_pass(store, cfg)
+
+        row = store.conn.execute(
+            """
+            SELECT data FROM events
+            WHERE category='decay' AND event='cleanup_pass_completed'
+            """
+        ).fetchone()
+        assert row is not None
+        assert json.loads(row["data"]) == stats
+
     def test_weight_invariant_after_cleanup(self, store):
         """Any conduit surviving cleanup_pass has effective_weight >= WEIGHT_FLOOR."""
         from flux.propagation import effective_weight
@@ -290,6 +305,18 @@ class TestExpiryPass:
     def test_returns_correct_stats_structure(self, store):
         stats = expiry_pass(store)
         assert "grains_archived" in stats
+
+    def test_expiry_pass_logs_event(self, store):
+        stats = expiry_pass(store)
+
+        row = store.conn.execute(
+            """
+            SELECT data FROM events
+            WHERE category='decay' AND event='expiry_pass_completed'
+            """
+        ).fetchone()
+        assert row is not None
+        assert json.loads(row["data"]) == stats
 
 
 # ===================================================================== integration

--- a/tests/test_embedding_lazy.py
+++ b/tests/test_embedding_lazy.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import builtins
 
+from flux import Config, FluxStore
 from flux.embedding import SentenceTransformerBackend
+from flux.embedding import vector_fallback
 
 
 def test_sentence_transformer_backend_does_not_import_model_on_init(monkeypatch):
@@ -20,3 +22,25 @@ def test_sentence_transformer_backend_does_not_import_model_on_init(monkeypatch)
 
     assert backend.model_name == "lazy-test-model"
     assert backend._model is None
+
+
+def test_vector_fallback_does_not_embed_when_store_has_no_embeddings(tmp_path):
+    class FailingEmbeddingBackend:
+        def embed(self, text: str) -> list[float]:
+            raise AssertionError("empty vector fallback should not load/embed")
+
+        def embed_batch(self, texts: list[str]) -> list[list[float]]:
+            raise AssertionError("empty vector fallback should not batch embed")
+
+    with FluxStore(tmp_path / "test.db") as store:
+        existing_results = [("existing-grain", 0.25)]
+
+        results = vector_fallback(
+            store,
+            "query that would otherwise trigger cold model load",
+            FailingEmbeddingBackend(),
+            existing_results,
+            cfg=Config(),
+        )
+
+    assert results == existing_results

--- a/tests/test_embedding_lazy.py
+++ b/tests/test_embedding_lazy.py
@@ -1,0 +1,22 @@
+"""Tests for lazy embedding backend startup behavior."""
+from __future__ import annotations
+
+import builtins
+
+from flux.embedding import SentenceTransformerBackend
+
+
+def test_sentence_transformer_backend_does_not_import_model_on_init(monkeypatch):
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "sentence_transformers":
+            raise AssertionError("sentence_transformers should load on first embed, not init")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    backend = SentenceTransformerBackend("lazy-test-model")
+
+    assert backend.model_name == "lazy-test-model"
+    assert backend._model is None

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -21,6 +21,7 @@ from flux.extraction import (
     _fallback_tokenize,
     decompose_query,
     extract_and_store_grains,
+    rebuild_missing_graph,
 )
 from flux.llm import (
     OllamaBackend,
@@ -371,6 +372,36 @@ class TestExtractAndStoreGrains:
             def complete(self, prompt): return "[]"
         new_ids = extract_and_store_grains("hi", "hello", EmptyLLM(), MockEmbeddingBackend(), store)
         assert new_ids == []
+
+
+class TestRebuildMissingGraph:
+    def test_rebuilds_bare_active_grain(self, store):
+        class FailingLLM:
+            def complete(self, prompt):
+                raise RuntimeError("llm unavailable")
+
+        grain = Grain(content="Dashboard should show conduits", provenance="user_stated")
+        store.insert_grain(grain)
+
+        stats = rebuild_missing_graph(store, FailingLLM(), MockEmbeddingBackend())
+
+        assert stats["grains_rebuilt"] == 1
+        assert stats["embeddings_created"] == 1
+        assert stats["conduits_created"] >= 1
+        embedding_count = store.conn.execute(
+            "SELECT COUNT(*) AS n FROM grain_embeddings WHERE grain_id = ?",
+            (grain.id,),
+        ).fetchone()["n"]
+        assert embedding_count == 1
+
+    def test_skips_already_connected_grain(self, store):
+        llm = MockLLMBackend()
+        emb = MockEmbeddingBackend()
+        extract_and_store_grains("I prefer Python.", "Python is useful.", llm, emb, store)
+
+        stats = rebuild_missing_graph(store, llm, emb)
+
+        assert stats["grains_rebuilt"] == 0
 
 
 # ===================================================================== _fallback_tokenize

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -142,6 +142,15 @@ class TestComputeEventSignals:
         sigs = _compute_event_signals(store, now)
         assert sigs["retrieval_success_rate"] == pytest.approx(0.6)
 
+    def test_retrieval_success_rate_counts_one_success_per_trace(self, store):
+        now = _now()
+        log_event(store, "retrieval", "grains_returned", {"hop_count": 2}, trace_id="trace-1", now=now)
+        log_event(store, "retrieval", "grains_returned", {"hop_count": 2}, trace_id="trace-2", now=now)
+        log_event(store, "feedback", "retrieval_successful", {}, trace_id="trace-1", now=now)
+        log_event(store, "feedback", "retrieval_successful", {}, trace_id="trace-1", now=now)
+        sigs = _compute_event_signals(store, now)
+        assert sigs["retrieval_success_rate"] == pytest.approx(0.5)
+
     def test_avg_hops_from_events(self, store):
         now = _now()
         log_event(store, "retrieval", "grains_returned", {"hop_count": 2}, now=now)

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -1,6 +1,7 @@
 """Tests for promotion.py — grain promotion (Track 1 Step 8)."""
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -207,6 +208,30 @@ class TestCheckPromotion:
         assert promoted
         updated_conduit = store.get_conduit(c.id)
         assert updated_conduit.decay_class == "core"
+
+    def test_promotion_logs_health_facing_event(self, store):
+        cfg = Config(PROMOTION_THRESHOLD=1, CLUSTER_TOUCH_THRESHOLD=0.1)
+        g = _grain(); e = _entry("logging")
+        store.insert_grain(g); store.insert_entry(e)
+        store.conn.execute(
+            "INSERT INTO entry_cluster_membership (entry_id, cluster_id, weight) VALUES (?, ?, ?)",
+            (e.id, "cluster-logging", 1.0),
+        )
+
+        promoted = check_promotion(store, g.id, _make_trace(e.id, g.id), cfg, trace_id="trace-promo")
+
+        assert promoted
+        row = store.conn.execute(
+            """
+            SELECT trace_id, data FROM events
+            WHERE category='feedback' AND event='promotion_triggered'
+            """
+        ).fetchone()
+        assert row is not None
+        assert row["trace_id"] == "trace-promo"
+        data = json.loads(row["data"])
+        assert data["grain_id"] == g.id
+        assert data["context_spread"] == 1
 
     def test_context_spread_monotonically_nondecreasing(self, store):
         """context_spread must never decrease between successive check_promotion calls."""

--- a/tests/test_reinforcement.py
+++ b/tests/test_reinforcement.py
@@ -1,6 +1,7 @@
 """Reinforcement and penalization tests (Section 4.3, 4.4, 7.2)."""
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -53,6 +54,26 @@ def test_reinforce_widens_conduit_to_successful_grain(store):
     # Spec 4.3: weight += LEARNING_RATE * (1 - weight) = 0.5 + 0.05 * 0.5 = 0.525
     assert after.weight == pytest.approx(0.525, rel=1e-3)
     assert after.use_count == c.use_count + 1
+
+
+def test_reinforce_logs_highway_when_threshold_crossed(store):
+    e = _entry(store, "x")
+    g = _grain(store, "g")
+    c = _conduit(store, e.id, g.id, weight=0.79)
+
+    reinforce(store, [_trace_step(c)], [g.id], trace_id="trace-highway")
+
+    row = store.conn.execute(
+        """
+        SELECT trace_id, data FROM events
+        WHERE category='feedback' AND event='highway_formed'
+        """
+    ).fetchone()
+    assert row is not None
+    assert row["trace_id"] == "trace-highway"
+    data = json.loads(row["data"])
+    assert data["conduit_id"] == c.id
+    assert data["previous_weight"] < 0.80 <= data["new_weight"]
 
 
 def test_reinforce_caps_at_ceiling(store):
@@ -147,6 +168,17 @@ def test_reinforce_creates_shortcut_once_threshold_met(store):
     assert shortcut.weight == pytest.approx(cfg.INITIAL_SHORTCUT_WEIGHT)
     assert shortcut.direction == "bidirectional"
 
+    row = store.conn.execute(
+        """
+        SELECT data FROM events
+        WHERE category='feedback' AND event='shortcut_created'
+        """
+    ).fetchone()
+    assert row is not None
+    data = json.loads(row["data"])
+    assert data["conduit_id"] == shortcut.id
+    assert data["co_retrieval_count"] == cfg.SHORTCUT_THRESHOLD
+
 
 def test_reinforce_reinforces_existing_shortcut(store):
     """Co-retrieving a pair that already has a shortcut widens the shortcut."""
@@ -225,6 +257,18 @@ def test_penalize_narrows_conduit_to_failed_grain(store):
     after = store.get_conduit(c.id)
     # Spec 4.4: weight *= DECAY_FACTOR (0.85) = 0.425
     assert after.weight == pytest.approx(0.5 * DEFAULT_CONFIG.DECAY_FACTOR, rel=1e-3)
+
+    row = store.conn.execute(
+        """
+        SELECT data FROM events
+        WHERE category='feedback' AND event='conduit_penalized'
+        """
+    ).fetchone()
+    assert row is not None
+    data = json.loads(row["data"])
+    assert data["conduit_id"] == c.id
+    assert data["weight_drop"] == pytest.approx(0.5 * (1 - DEFAULT_CONFIG.DECAY_FACTOR))
+    assert data["deleted"] is False
 
 
 def test_penalize_deletes_conduit_below_floor(store):

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -44,6 +44,15 @@ def client(svc, cfg):
 
 # ---------------------------------------------------------------- /health
 
+class TestRootEndpoint:
+    def test_root_returns_service_info(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "Flux Memory"
+        assert body["health"] == "/health"
+
+
 class TestHealthEndpoint:
     def test_health_returns_200(self, client):
         resp = client.get("/health")

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -58,6 +58,26 @@ class TestFluxStore:
         count = store.conn.execute("SELECT COUNT(*) AS n FROM entries").fetchone()["n"]
         assert count >= 1
 
+    def test_llm_failure_fallback_still_wires_graph(self, store):
+        class FailingLLM:
+            def complete(self, prompt):
+                raise RuntimeError("llm unavailable")
+
+        emb = MockEmbeddingBackend()
+        gid = flux_store("User prefers compact dashboard metrics", store=store,
+                         llm=FailingLLM(), emb=emb)
+
+        assert store.get_grain(gid) is not None
+        embedding_count = store.conn.execute(
+            "SELECT COUNT(*) AS n FROM grain_embeddings WHERE grain_id = ?",
+            (gid,),
+        ).fetchone()["n"]
+        entry_count = store.conn.execute("SELECT COUNT(*) AS n FROM entries").fetchone()["n"]
+        conduit_count = store.conn.execute("SELECT COUNT(*) AS n FROM conduits").fetchone()["n"]
+        assert embedding_count == 1
+        assert entry_count >= 1
+        assert conduit_count >= 1
+
 
 # ===================================================================== flux_retrieve
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -64,6 +64,17 @@ class TestExportJson:
         assert data["nodes"] == []
         assert data["links"] == []
 
+    def test_stats_include_graph_artifact_counts(self, populated_store):
+        store, g1, *_ = populated_store
+        store_embedding(store, g1.id, MockEmbeddingBackend().embed(g1.content), "mock")
+
+        data = export_json(store)
+
+        assert data["stats"]["grains"] == 2
+        assert data["stats"]["entries"] == 1
+        assert data["stats"]["conduits"] == 1
+        assert data["stats"]["embeddings"] == 1
+
 
 class TestExportGraphml:
     def test_returns_string(self, populated_store):


### PR DESCRIPTION
## Summary

This PR fixes the Windows startup/MCP integration path and includes the follow-up dashboard and Flux workflow work from validation.

### Fixes and improvements

- Add `python -m flux` fallback via `src/flux/__main__.py` for Windows installs where `flux.exe` is outside PATH.
- Make `flux start` launch REST/dashboard only, log to `~/.flux/<name>/flux.log`, wait for readiness, and report partial startup failures.
- Add explicit stdio MCP command: `flux mcp --name <instance>`.
- Add `flux mcp-config --name <instance>` to generate Codex, Claude Desktop, and Cursor snippets.
- Clarify that stdio MCP is client-launched and not automatically started by `flux start`.
- Add `flux start --broadcast` to expose the dashboard on the local network while keeping REST local-only by default.
- Add mobile-friendly dashboard behavior: graph-first layout, fixed mobile controls, touch node dragging, bottom-sheet panels, folded-screen compact mode, and `/mobile-preview`.
- Add reusable mobile design pack under `design/mobile-preview` with a handoff prompt/spec for other Flux systems.
- Prevent mobile search input zoom by using a 16px mobile search field and blurring the field on Enter.
- Add explicit dashboard deselect control and Escape key support for clearing selected nodes/edges.
- Sharpen graph labels on high-DPI/mobile screens by scaling the canvas backing store to `devicePixelRatio`.
- Improve embedding warmup and retrieval concurrency for cold-start behavior.
- Add health instrumentation events and dashboard design guidance.
- Redesign the dashboard with a faster canvas graph, richer system panels, and interactive graph controls.
- Fix dashboard search so matching nodes are highlighted while nonmatches remain visible but dimmed.
- Animate conduit-specific events (`conduit_reinforced`, `conduit_penalized`, `highway_formed`, `shortcut_created`) on the exact edge and endpoint nodes.
- Fix `retrieval_success_rate` so multiple positive feedback events on one trace cannot exceed 100%.
- Document that `flux_onboard` instructions must be persisted into an always-loaded instruction surface such as `AGENTS.md`, not only into retrievable memory.

## Validation

Passed locally:

```cmd
python -m py_compile src\flux\dashboard.py src\flux\health.py
node --check %TEMP%\flux-dashboard-inline.js
python -m pytest
```

Full test result: `425 passed`.

Dashboard verification covered live graph rendering, high-DPI mobile canvas scaling, mobile search Enter blur/no-focus behavior, selection clearing, Escape deselect, mobile viewport behavior, bottom-sheet opening, LAN dashboard reachability, `/mobile-preview`, conduit-specific edge animation, structural refresh guards for stable activity animation, and retrieval-success rate capped by trace-scoped counting. Browser console errors: none observed.

## Notes

`pip install` output itself is controlled by pip, so this PR improves first-run CLI behavior and docs rather than relying on post-install scripts. Stdio MCP still requires adding the generated client config snippet to each client. The current Flux agent-compliance finding is documented as an onboarding persistence requirement.
