### PR TITLE
[codex] Add AI-agnostic caller attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ flux_onboard() -> returns workflow instructions + operating mode
 2. `flux_store(content, provenance)` - save new facts after responding
 3. `flux_feedback(trace_id, grain_id, useful)` - rate each retrieved grain
 
+Every client should also send a portable caller identity:
+
+- `client`: any stable AI/tool name, such as `codex`, `claude`, or `local-agent-1`
+- `role`: one of `chat`, `memory_writer`, `background_lookup`, `system`, `admin`, `test`
+
+Use `caller_id="<client>:<role>"`, for example `local-agent-1:chat`.
+MCP clients may instead send separate `client` and `role` fields.
+
 For clients such as Codex, save the `flux_onboard` instructions into an
 always-loaded instruction surface, such as a project or user `AGENTS.md`.
 Saving the workflow only as a memory note is not enough, because the agent must
@@ -170,7 +178,9 @@ GET  /health
 GET  /grains?status=active&limit=50
 ```
 
-Pass `X-Caller-Id: agent-name` header for per-caller rate limiting and tracking.
+Pass `X-Flux-Client` and `X-Flux-Role` headers for caller attribution, or use
+legacy `X-Caller-Id: <client>:<role>`. Dashboard compliance groups calls by
+client and role.
 
 ## Python SDK
 

--- a/docs/flux-memory-docs.md
+++ b/docs/flux-memory-docs.md
@@ -2290,6 +2290,23 @@ Three separate channels:
 
 Feedback lives on the read channel because it operates on a retrieval trace.
 
+**Caller attribution**
+
+All clients identify themselves with an AI-agnostic caller contract:
+
+- `client`: any stable free-form AI/tool name, e.g. `codex`, `claude`, `local-agent-1`, or a private assistant name.
+- `role`: a controlled role describing why the call happened: `chat`, `memory_writer`, `background_lookup`, `system`, `admin`, or `test`.
+
+The canonical single-field form is `caller_id="<client>:<role>"`, such as
+`local-agent-1:chat` or `my-private-bot:memory_writer`. MCP clients may send
+separate `client` and `role` fields; REST clients may send `X-Flux-Client` and
+`X-Flux-Role` headers. Flux normalizes legacy caller names such as
+`ambient_suggestions`, `codex_ambient_*`, and `memory_writing_agent` into the
+same client/role shape for dashboard grouping and feedback enforcement.
+
+`flux_onboard` returns this contract and instructs clients to save it in their
+persistent/core instructions so future sessions keep using the same identity.
+
 ### 13.6 Ingestion Model
 
 A separate extractor LLM reads conversations and emits atomic grains via the write channel. Flux does not process raw conversations itself. The extractor is external to Flux.

--- a/src/flux/dashboard.py
+++ b/src/flux/dashboard.py
@@ -747,8 +747,9 @@ function renderHealth() {
         ${callerFeedback.map(c => {
           const rate = Number(c.rate) || 0;
           const healthy = c.healthy === true || rate >= 0.8;
+          const displayName = c.display_name || c.caller_id || 'Unknown caller';
           return `<div class="caller-row ${healthy ? 'good' : 'bad'}">
-            <div class="caller-name" title="${esc(c.caller_id)}">${esc(c.caller_id)}</div>
+            <div class="caller-name" title="${esc(c.caller_id)}">${esc(displayName)}</div>
             <div class="caller-rate" style="color:${healthy?'var(--green)':'var(--rose)'}">${pct(rate)}</div>
             <div class="caller-meta">${esc(c.received)} / ${esc(c.expected)} feedback · ${esc(c.missing)} missing · ${esc(c.retrievals)} retrievals</div>
           </div>`;

--- a/src/flux/health.py
+++ b/src/flux/health.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import json
 import logging
 import logging.handlers
+import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -162,6 +163,111 @@ _HEALTHY_RANGES: dict[str, dict] = {
 
 # ---------------------------------------------------------------- event logging
 
+_CALLER_ROLE_LABELS = {
+    "chat": "Chat",
+    "memory_writer": "Memory Writer",
+    "background_lookup": "Background Lookup",
+    "system": "System",
+    "admin": "Admin",
+    "test": "Test",
+    "legacy": "Legacy",
+    "other": "Other",
+}
+_VALID_CALLER_ROLES = set(_CALLER_ROLE_LABELS)
+_ROLE_ALIASES = {
+    "memory_writer": "memory_writer",
+    "memory_writing": "memory_writer",
+    "memory": "memory_writer",
+    "writer": "memory_writer",
+    "background_lookup": "background_lookup",
+    "background": "background_lookup",
+    "ambient": "background_lookup",
+    "ambient_suggestions": "background_lookup",
+    "suggestions": "background_lookup",
+}
+
+
+def _slug(value: Any, default: str) -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9_.-]+", "_", text)
+    text = re.sub(r"_+", "_", text).strip("_")
+    return text or default
+
+
+def _caller_role(value: Any, default: str = "chat") -> str:
+    role = _slug(value, default).replace("-", "_")
+    role = _ROLE_ALIASES.get(role, role)
+    return role if role in _VALID_CALLER_ROLES else "other"
+
+
+def _display_client(client: str) -> str:
+    parts = [p for p in re.split(r"[-_:.]+", client) if p]
+    return " ".join(part.capitalize() for part in parts) if parts else "Unknown"
+
+
+def compose_caller_id(
+    client: str | None = None,
+    role: str | None = None,
+    *,
+    fallback: str | None = None,
+) -> str:
+    """Return the portable caller_id form: arbitrary client + controlled role."""
+    if client or role:
+        resolved_client = _slug(client or fallback, "unknown")
+        resolved_role = _caller_role(role, "chat")
+        return f"{resolved_client}:{resolved_role}"
+    return str(fallback or "unknown").strip() or "unknown"
+
+
+def caller_identity(
+    caller_id: str | None,
+    query: str | None = None,
+    *,
+    client: str | None = None,
+    role: str | None = None,
+) -> dict[str, str]:
+    """Resolve legacy and portable caller attribution into client/role fields."""
+    query_l = str(query or "").strip().lower()
+
+    if client or role:
+        client_id, role_id = compose_caller_id(client, role, fallback=caller_id).split(":", 1)
+    else:
+        raw = str(caller_id or "").strip()
+        raw_l = raw.lower()
+        ambient_prompt = "ambient suggestions" in query_l
+        memory_prompt = "memory writing agent" in query_l
+
+        if (
+            raw_l == "ambient_suggestions"
+            or raw_l.startswith("codex_ambient")
+            or (raw_l in {"codex", "default", "unknown", "anonymous", ""} and ambient_prompt)
+        ):
+            client_id, role_id = "codex", "background_lookup"
+        elif (
+            raw_l == "memory_writing_agent"
+            or (raw_l in {"codex", "default", "unknown", "anonymous", ""} and memory_prompt)
+        ):
+            client_id, role_id = "codex", "memory_writer"
+        elif raw_l in {"", "default", "unknown"}:
+            client_id, role_id = "unknown", "legacy"
+        elif raw_l == "anonymous":
+            client_id, role_id = "anonymous", "legacy"
+        elif ":" in raw:
+            raw_client, raw_role = raw.split(":", 1)
+            client_id = _slug(raw_client, "unknown")
+            role_id = _caller_role(raw_role, "chat")
+        else:
+            client_id = _slug(raw, "unknown")
+            role_id = "chat"
+
+    caller = f"{client_id}:{role_id}"
+    return {
+        "caller_id": caller,
+        "client": client_id,
+        "role": role_id,
+        "display_name": f"{_display_client(client_id)} / {_CALLER_ROLE_LABELS[role_id]}",
+    }
+
 def log_event(
     store: FluxStore,
     category: str,
@@ -181,6 +287,17 @@ def log_event(
     payload = dict(data or {})
     if caller_id is not None and "caller_id" not in payload:
         payload["caller_id"] = caller_id
+    if "caller_id" in payload or "caller_client" in payload or "caller_role" in payload:
+        identity = caller_identity(
+            payload.get("caller_id"),
+            payload.get("query"),
+            client=payload.get("caller_client"),
+            role=payload.get("caller_role"),
+        )
+        payload["caller_id"] = identity["caller_id"]
+        payload["caller_client"] = identity["client"]
+        payload["caller_role"] = identity["role"]
+        payload["caller_display_name"] = identity["display_name"]
     store.conn.execute(
         """
         INSERT INTO events (id, timestamp, category, event, trace_id, data)
@@ -305,20 +422,25 @@ def _event_payload(row: Any) -> dict[str, Any]:
 
 
 def normalize_caller_id(caller_id: str | None, query: str | None = None) -> str:
-    caller_id = str(caller_id or "unknown").strip() or "unknown"
-    query = str(query or "").strip().lower()
-
-    if caller_id in {"codex", "default", "unknown"}:
-        if "ambient suggestions" in query:
-            return "ambient_suggestions"
-        if "memory writing agent" in query:
-            return "memory_writing_agent"
-
-    return caller_id
+    return caller_identity(caller_id, query)["caller_id"]
 
 
 def _caller_id_from_payload(payload: dict[str, Any]) -> str:
-    return normalize_caller_id(payload.get("caller_id"), payload.get("query"))
+    return caller_identity(
+        payload.get("caller_id"),
+        payload.get("query"),
+        client=payload.get("caller_client"),
+        role=payload.get("caller_role"),
+    )["caller_id"]
+
+
+def _caller_identity_from_payload(payload: dict[str, Any]) -> dict[str, str]:
+    return caller_identity(
+        payload.get("caller_id"),
+        payload.get("query"),
+        client=payload.get("caller_client"),
+        role=payload.get("caller_role"),
+    )
 
 
 def _parse_event_timestamp(timestamp: str | None) -> datetime | None:
@@ -534,12 +656,16 @@ def _feedback_compliance_by_caller(
     for row in retrieval_rows:
         trace_id = row["trace_id"]
         payload = _event_payload(row)
-        caller_id = _caller_id_from_payload(payload)
+        identity = _caller_identity_from_payload(payload)
+        caller_id = identity["caller_id"]
         entry = stats.setdefault(caller_id, {
             "expected": 0.0,
             "received": 0.0,
             "missing": 0.0,
             "retrievals": 0.0,
+            "client": identity["client"],
+            "role": identity["role"],
+            "display_name": identity["display_name"],
         })
         entry["retrievals"] += 1
 
@@ -590,6 +716,9 @@ def _caller_feedback_summary(
         rate = float(item.get("rate", 1.0))
         summary.append({
             "caller_id": caller_id,
+            "client": item["client"],
+            "role": item["role"],
+            "display_name": item["display_name"],
             "rate": rate,
             "healthy": rate >= 0.80,
             "expected": item["expected"],

--- a/src/flux/mcp_server.py
+++ b/src/flux/mcp_server.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from .config import Config, DEFAULT_CONFIG
 from .embedding import EmbeddingBackend
-from .health import flux_health
+from .health import compose_caller_id, flux_health
 from .llm import LLMBackend
 from .retrieval import flux_feedback, flux_retrieve, flux_store
 from .storage import FluxStore
@@ -48,6 +48,25 @@ You are connected to Flux Memory, a self-organizing retrieval fabric.
    - useful=true  if you actually used the grain in your response
    - useful=false if it was irrelevant
    This is how Flux learns. Missing feedback degrades the graph.
+
+## Caller identity
+
+Use a portable caller identity on every Flux call. Pick any stable client name
+for your AI/tool, then pair it with one of these roles:
+
+- chat
+- memory_writer
+- background_lookup
+- system
+- admin
+- test
+
+Preferred format: `caller_id="<client>:<role>"`.
+Examples: `my-ai:chat`, `local-agent-1:memory_writer`.
+
+If your client supports separate fields, send `client` and `role`; Flux will
+convert them to the same `client:role` form. Save this caller identity contract
+to your persistent/core instructions so future sessions use the same identity.
 
 ## Operating mode: {mode}
 
@@ -118,8 +137,17 @@ def build_mcp_server(
                         },
                         "caller_id": {
                             "type": "string",
-                            "description": "Identifier of the calling agent.",
+                            "description": "Portable caller identity. Prefer '<client>:<role>'.",
                             "default": "default",
+                        },
+                        "client": {
+                            "type": "string",
+                            "description": "Stable free-form AI/tool name, e.g. codex or local-agent-1.",
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": ["chat", "memory_writer", "background_lookup", "system", "admin", "test"],
+                            "description": "Standard caller role for this Flux call.",
                         },
                     },
                     "required": ["content"],
@@ -137,8 +165,17 @@ def build_mcp_server(
                         },
                         "caller_id": {
                             "type": "string",
-                            "description": "Identifier of the calling agent.",
+                            "description": "Portable caller identity. Prefer '<client>:<role>'.",
                             "default": "default",
+                        },
+                        "client": {
+                            "type": "string",
+                            "description": "Stable free-form AI/tool name, e.g. codex or local-agent-1.",
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": ["chat", "memory_writer", "background_lookup", "system", "admin", "test"],
+                            "description": "Standard caller role for this Flux call.",
                         },
                     },
                     "required": ["query"],
@@ -167,8 +204,17 @@ def build_mcp_server(
                         },
                         "caller_id": {
                             "type": "string",
-                            "description": "Identifier of the calling agent.",
+                            "description": "Portable caller identity. Prefer '<client>:<role>'.",
                             "default": "default",
+                        },
+                        "client": {
+                            "type": "string",
+                            "description": "Stable free-form AI/tool name, e.g. codex or local-agent-1.",
+                        },
+                        "role": {
+                            "type": "string",
+                            "enum": ["chat", "memory_writer", "background_lookup", "system", "admin", "test"],
+                            "description": "Standard caller role for this Flux call.",
                         },
                     },
                     "required": ["trace_id", "grain_id", "useful"],
@@ -181,6 +227,8 @@ def build_mcp_server(
                     "type": "object",
                     "properties": {
                         "caller_id": {"type": "string", "default": "default"},
+                        "client": {"type": "string"},
+                        "role": {"type": "string"},
                     },
                 },
             ),
@@ -204,6 +252,8 @@ def build_mcp_server(
                             "default": 50,
                         },
                         "caller_id": {"type": "string", "default": "default"},
+                        "client": {"type": "string"},
+                        "role": {"type": "string"},
                     },
                 },
             ),
@@ -218,6 +268,8 @@ def build_mcp_server(
                     "type": "object",
                     "properties": {
                         "caller_id": {"type": "string", "default": "default"},
+                        "client": {"type": "string"},
+                        "role": {"type": "string"},
                     },
                 },
             ),
@@ -248,7 +300,11 @@ def _dispatch(
     cfg: Config,
     service=None,
 ) -> Any:
-    caller_id = args.get("caller_id", "default")
+    caller_id = compose_caller_id(
+        args.get("client"),
+        args.get("role"),
+        fallback=args.get("caller_id", "default"),
+    )
 
     if name == "flux_store":
         if service is not None:

--- a/src/flux/rest_api.py
+++ b/src/flux/rest_api.py
@@ -11,7 +11,7 @@ Endpoints:
   GET  /health             current health report
   GET  /grains             list grains, optional ?status= filter
 
-All requests accept an optional X-Caller-Id header for per-caller tracking.
+All requests accept caller attribution headers for per-caller tracking.
 
 Usage (programmatic):
     from flux.rest_api import build_app
@@ -25,11 +25,14 @@ import logging
 from typing import Any, List
 
 from .config import Config, DEFAULT_CONFIG
+from .health import compose_caller_id
 from .service import FluxService
 
 logger = logging.getLogger(__name__)
 
 _CALLER_HEADER = "X-Caller-Id"
+_CALLER_CLIENT_HEADER = "X-Flux-Client"
+_CALLER_ROLE_HEADER = "X-Flux-Role"
 _DEFAULT_CALLER = "anonymous"
 
 try:
@@ -76,7 +79,11 @@ def build_app(service: "FluxService", cfg: "Config" = DEFAULT_CONFIG):
     # ------------------------------------------------------------------
 
     def _caller(request: Request) -> str:
-        return request.headers.get(_CALLER_HEADER, _DEFAULT_CALLER)
+        return compose_caller_id(
+            request.headers.get(_CALLER_CLIENT_HEADER),
+            request.headers.get(_CALLER_ROLE_HEADER),
+            fallback=request.headers.get(_CALLER_HEADER, _DEFAULT_CALLER),
+        )
 
     # ------------------------------------------------------------------
     # Endpoints

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -372,16 +372,19 @@ class TestFluxHealth:
         caller = next(
             (
                 c for c in result["caller_feedback"]
-                if c["caller_id"] == "ambient_suggestions"
+                if c["caller_id"] == "codex:background_lookup"
             ),
             None,
         )
         assert caller is not None
+        assert caller["client"] == "codex"
+        assert caller["role"] == "background_lookup"
+        assert caller["display_name"] == "Codex / Background Lookup"
         assert caller["rate"] == pytest.approx(0.0)
         assert caller["missing"] == pytest.approx(1.0)
         assert caller["healthy"] is False
         assert not any(
-            w["signal"] == "feedback_compliance_rate:ambient_suggestions"
+            w["signal"] == "feedback_compliance_rate:codex:background_lookup"
             for w in result["active_warnings"]
         )
 
@@ -414,5 +417,51 @@ class TestFluxHealth:
         result = flux_health(store, now=now)
         callers = {c["caller_id"] for c in result["caller_feedback"]}
 
-        assert "ambient_suggestions" in callers
-        assert "codex" not in callers
+        assert "codex:background_lookup" in callers
+        assert "codex:chat" not in callers
+
+    def test_feedback_compliance_accepts_arbitrary_client_with_standard_role(self, store):
+        now = _now()
+        log_event(
+            store,
+            "retrieval",
+            "grains_returned",
+            {
+                "grain_ids": ["g1"],
+                "grains_count": 1,
+                "caller_id": "my-custom-bot:memory_writer",
+            },
+            trace_id="trace-custom",
+            now=now,
+        )
+
+        result = flux_health(store, now=now)
+        caller = next(
+            c for c in result["caller_feedback"]
+            if c["caller_id"] == "my-custom-bot:memory_writer"
+        )
+
+        assert caller["client"] == "my-custom-bot"
+        assert caller["role"] == "memory_writer"
+        assert caller["display_name"] == "My Custom Bot / Memory Writer"
+
+    def test_feedback_compliance_maps_legacy_memory_writer(self, store):
+        now = _now()
+        log_event(
+            store,
+            "retrieval",
+            "grains_returned",
+            {
+                "grain_ids": ["g1"],
+                "grains_count": 1,
+                "caller_id": "memory_writing_agent",
+            },
+            trace_id="trace-writer",
+            now=now,
+        )
+
+        result = flux_health(store, now=now)
+        callers = {c["caller_id"] for c in result["caller_feedback"]}
+
+        assert "codex:memory_writer" in callers
+        assert "memory_writing_agent" not in callers

--- a/tests/test_mcp_v6.py
+++ b/tests/test_mcp_v6.py
@@ -73,6 +73,16 @@ class TestFluxOnboard:
         assert "flux_store" in instructions
         assert "flux_feedback" in instructions
 
+    def test_onboard_instructions_define_generic_caller_identity(self, store, cfg):
+        result = dispatch("flux_onboard", {}, store, cfg)
+        instructions = result["instructions"]
+
+        assert "client" in instructions
+        assert "role" in instructions
+        assert "client:role" in instructions
+        assert "memory_writer" in instructions
+        assert "Save these instructions" in instructions
+
 
 # ---------------------------------------------------------------- flux_list_grains
 
@@ -137,6 +147,25 @@ class TestFluxRetrieveCaller:
         result = dispatch("flux_retrieve", {"query": "retrievable", "caller_id": "agent-b"}, store, cfg)
         assert "grains" in result
         assert "trace_id" in result
+
+    def test_retrieve_accepts_client_and_role_fields(self, store, cfg):
+        dispatch("flux_store", {"content": "portable caller identity"}, store, cfg)
+        result = dispatch(
+            "flux_retrieve",
+            {
+                "query": "portable caller identity",
+                "client": "my-custom-bot",
+                "role": "background_lookup",
+            },
+            store,
+            cfg,
+        )
+
+        assert "trace_id" in result
+
+        health = dispatch("flux_health", {}, store, cfg)
+        callers = {c["caller_id"] for c in health["caller_feedback"]}
+        assert "my-custom-bot:background_lookup" in callers
 
 
 # ---------------------------------------------------------------- unknown tool

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -149,6 +149,22 @@ class TestRetrieveEndpoint:
         )
         assert resp.status_code == 200
 
+    def test_retrieve_with_caller_client_and_role_headers(self, client):
+        client.post("/store", json={"content": "portable REST caller"})
+        resp = client.post(
+            "/retrieve",
+            json={"query": "portable REST caller"},
+            headers={
+                "X-Flux-Client": "local-agent-1",
+                "X-Flux-Role": "background_lookup",
+            },
+        )
+        assert resp.status_code == 200
+
+        health = client.get("/health").json()
+        callers = {c["caller_id"] for c in health["caller_feedback"]}
+        assert "local-agent-1:background_lookup" in callers
+
 
 # ---------------------------------------------------------------- /feedback
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -192,7 +192,7 @@ class TestFluxRetrieve:
 
         err = excinfo.value
         assert getattr(err, "recoverable", False) is True
-        assert getattr(err, "caller_id", None) == "agent-a"
+        assert getattr(err, "caller_id", None) == "agent-a:chat"
         assert getattr(err, "missing", None) == 2
         assert getattr(err, "pending_traces", None) == [
             {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -160,7 +160,7 @@ class TestFluxServiceRetrieve:
             """
         ).fetchone()
 
-        assert json.loads(row["data"])["caller_id"] == "agent-retrieve"
+        assert json.loads(row["data"])["caller_id"] == "agent-retrieve:chat"
 
 
 # ---------------------------------------------------------------- feedback
@@ -201,7 +201,7 @@ class TestFluxServiceFeedback:
             """
         ).fetchone()
 
-        assert json.loads(row["data"])["caller_id"] == "agent-feedback"
+        assert json.loads(row["data"])["caller_id"] == "agent-feedback:chat"
 
 
 # ---------------------------------------------------------------- health and list


### PR DESCRIPTION
## Summary
- add AI-agnostic caller attribution with arbitrary client names and standard roles
- normalize legacy Codex helper labels into client/role identities for dashboard and feedback compliance
- update MCP onboarding, MCP schema, REST headers, dashboard labels, and docs

## Validation
- python -m pytest -> 444 passed
